### PR TITLE
fix: swapped variable names within kubeinit_okd_dependencies

### DIFF
--- a/kubeinit/roles/kubeinit_okd/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_okd/defaults/main.yml
@@ -29,8 +29,8 @@ kubeinit_okd_pod_cidr: 10.100.0.0/14
 kubeinit_okd_service_cidr: 172.30.0.0/16
 
 kubeinit_okd_dependencies:
-  installer: https://github.com/openshift/okd/releases/download/4.5.0-0.okd-2020-10-03-012432/openshift-client-linux-4.5.0-0.okd-2020-10-03-012432.tar.gz
-  client: https://github.com/openshift/okd/releases/download/4.5.0-0.okd-2020-10-03-012432/openshift-install-linux-4.5.0-0.okd-2020-10-03-012432.tar.gz
+  client: https://github.com/openshift/okd/releases/download/4.5.0-0.okd-2020-10-03-012432/openshift-client-linux-4.5.0-0.okd-2020-10-03-012432.tar.gz
+  installer: https://github.com/openshift/okd/releases/download/4.5.0-0.okd-2020-10-03-012432/openshift-install-linux-4.5.0-0.okd-2020-10-03-012432.tar.gz
 kubeinit_okd_service_dependencies:
   - haproxy
   - httpd


### PR DESCRIPTION
Swaps the variables within kubeinit_okd_dependencies. Client was given the Installer's URL, and vice versa.