### PR TITLE
docs: add inventory and playbook diagrams

### DIFF
--- a/.github/workflows/docs_build_pr.yml
+++ b/.github/workflows/docs_build_pr.yml
@@ -12,6 +12,49 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Render the projects roles and inventory diagrams
+        run: |
+          sudo apt-get install graphviz -y
+          sudo python3 -m pip install --upgrade pip
+          sudo python3 -m pip install --upgrade virtualenv
+          sudo python3 -m pip install --upgrade setuptools
+          sudo python3 -m pip install --upgrade ansible-inventory-grapher
+          sudo python3 -m pip install --upgrade ansible-playbook-grapher
+
+          for f in ./playbooks/*; do
+              filename=$(basename $f)
+              echo "ansible-playbook-grapher ./playbooks/$filename --include-role-tasks -o ./docs/src/static/playbook_$filename"
+              ansible-playbook-grapher ./playbooks/$filename --include-role-tasks -o ./docs/src/static/playbook_$filename
+          cat << EOF >> ./docs/src/playbook_diagrams.rst
+
+          $filename playbook architecture
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+          .. image:: static/playbook_$filename.svg
+            :width: 400
+            :alt: Alternative text
+
+          EOF
+          done
+
+          for f in ./hosts/*; do
+              filename=$(basename $f)
+              echo "ansible-inventory-grapher -i ./hosts/$filename/inventory all -a 'rankdir=LR;' -q | dot -Tpng > ./docs/src/static/inventory_$filename.png"
+              ansible-inventory-grapher -i hosts/$filename/inventory all -a 'rankdir=LR;' -q | dot -Tpng > ./docs/src/static/inventory_$filename.png
+          cat << EOF >> ./docs/src/inventory_diagrams.rst
+
+          $filename inventory architecture
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+          .. image:: static/inventory_$filename.png
+            :width: 400
+            :alt: Alternative text
+
+          EOF
+          done
+
+          cat ./docs/src/playbook_diagrams.rst
+          cat ./docs/src/inventory_diagrams.rst
       - name: Render the changelog file
         run: |
           GITCHANGELOG_CONFIG_FILENAME=./tools/gitchangelog.rc ./tools/gitchangelog.py > ./docs/src/changelog.rst

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,49 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Render the projects roles and inventory diagrams
+        run: |
+          sudo apt-get install graphviz -y
+          sudo python3 -m pip install --upgrade pip
+          sudo python3 -m pip install --upgrade virtualenv
+          sudo python3 -m pip install --upgrade setuptools
+          sudo python3 -m pip install --upgrade ansible-inventory-grapher
+          sudo python3 -m pip install --upgrade ansible-playbook-grapher
+
+          for f in ./playbooks/*; do
+              filename=$(basename $f)
+              echo "ansible-playbook-grapher ./playbooks/$filename --include-role-tasks -o ./docs/src/static/playbook_$filename"
+              ansible-playbook-grapher ./playbooks/$filename --include-role-tasks -o ./docs/src/static/playbook_$filename
+          cat << EOF >> ./docs/src/playbook_diagrams.rst
+
+          $filename playbook architecture
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+          .. image:: static/playbook_$filename.svg
+            :width: 400
+            :alt: Alternative text
+
+          EOF
+          done
+
+          for f in ./hosts/*; do
+              filename=$(basename $f)
+              echo "ansible-inventory-grapher -i ./hosts/$filename/inventory all -a 'rankdir=LR;' -q | dot -Tpng > ./docs/src/static/inventory_$filename.png"
+              ansible-inventory-grapher -i hosts/$filename/inventory all -a 'rankdir=LR;' -q | dot -Tpng > ./docs/src/static/inventory_$filename.png
+          cat << EOF >> ./docs/src/inventory_diagrams.rst
+
+          $filename inventory architecture
+          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+          .. image:: static/inventory_$filename.png
+            :width: 400
+            :alt: Alternative text
+
+          EOF
+          done
+
+          cat ./docs/src/playbook_diagrams.rst
+          cat ./docs/src/inventory_diagrams.rst
       - name: Render the changelog file
         run: |
           GITCHANGELOG_CONFIG_FILENAME=./tools/gitchangelog.rc ./tools/gitchangelog.py > ./docs/src/changelog.rst

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -48,4 +48,6 @@ Content
    roles
    modules
    howtos_and_presentations
+   inventory_diagrams
+   playbook_diagrams
    changelog

--- a/docs/src/inventory_diagrams.rst
+++ b/docs/src/inventory_diagrams.rst
@@ -1,0 +1,6 @@
+==================
+Inventory diagrams
+==================
+
+The following are all the supported
+inventory architectural diagrams.

--- a/docs/src/playbook_diagrams.rst
+++ b/docs/src/playbook_diagrams.rst
@@ -1,0 +1,6 @@
+=================
+Playbook diagrams
+=================
+
+The following are all the supported
+playbooks architectural diagrams.


### PR DESCRIPTION
This patch renders automatically the
inventory and supported playbooks
for the supported scenarios.