### PR TITLE
fix: appends okd pullsecret to disconnected install

### DIFF
--- a/kubeinit/roles/kubeinit_okd/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_okd/defaults/main.yml
@@ -28,7 +28,11 @@ kubeinit_okd_registry: quay.io
 kubeinit_okd_registry_organization: openshift
 kubeinit_okd_registry_repository: okd
 kubeinit_okd_registry_release_tag: 4.5.0-0.okd-2020-10-15-235428
-kubeinit_okd_registry_pullsecret: '  {"auths":{"fake":{"auth": "bar"}}}'
+# The space after the first single quote is required, do not remove
+# Something in Ansible appears to be recognizing this as valid Python,
+# so it's getting transformed into a Python list and then serialized
+# using Python's str(), which is why we end up with the single-quoted values.
+kubeinit_okd_registry_pullsecret: '  {"auths":{"fakeregistry":{"auth": "foo", "email": "bar"}}}'
 
 kubeinit_okd_dependencies:
   client: "https://github.com/openshift/okd/releases/download/{{ kubeinit_okd_registry_release_tag }}/openshift-client-linux-{{ kubeinit_okd_registry_release_tag }}.tar.gz"

--- a/kubeinit/roles/kubeinit_registry/tasks/10_configure.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/10_configure.yml
@@ -71,23 +71,7 @@
     # using Python's str(), which is why we end up with the single-quoted values.
     disconnected_auth: '  {"{{ kubeinit_registry_uri }}": {"auth": "{{ disconnected_registry_up | b64encode }}", "email": "{{ kubeinit_registry_email }}" } }'
 
-- name: Write auth for disconnected to registry host
-  copy:
-    content: "{{ disconnected_auth }}"
-    dest: "{{ ansible_env.HOME }}/{{ kubeinit_registry_auth_file }}"
-    mode: '0755'
-    backup: yes
-    force: yes
-
-- name: Write auth for disconnected to localhost
-  copy:
-    content: "{{ disconnected_auth }}"
-    dest: "~/{{ kubeinit_registry_auth_file }}"
-    mode: '0755'
-    backup: yes
-    force: yes
-
-- name: append auth to pullsecret
+- name: append auths to pullsecret
   shell: |
     set -o pipefail
     echo '{{ kubeinit_registry_pullsecret }}' | jq -c \
@@ -97,9 +81,35 @@
   register: new_pullsecret
   changed_when: "new_pullsecret.rc == 0"
 
+- name: Write auth for disconnected to localhost
+  copy:
+    content: "{{ new_pullsecret.stdout }}"
+    dest: "~/{{ kubeinit_registry_auth_file }}"
+    mode: '0755'
+    backup: yes
+    force: yes
+
+- name: save kubeinit_okd_registry_pullsecret trimmed
+  shell: |
+    set -o pipefail
+    echo '{{ kubeinit_okd_registry_pullsecret }}' | jq .auths
+  args:
+    executable: /bin/bash
+  register: kubeinit_okd_registry_pullsecret_trimmed
+  changed_when: "kubeinit_okd_registry_pullsecret_trimmed.rc == 0"
+
+- name: append auth from OKD to pullsecret
+  shell: |
+    set -o pipefail
+    echo '{{ new_pullsecret.stdout }}' | jq '.auths += {{ kubeinit_okd_registry_pullsecret_trimmed.stdout }}'
+  args:
+    executable: /bin/bash
+  register: new_pullsecret_with_okd
+  changed_when: "new_pullsecret_with_okd.rc == 0"
+
 - name: set pullsecret with new auth
   set_fact:
-    kubeinit_registry_pullsecret: "{{ new_pullsecret.stdout }}"
+    kubeinit_registry_pullsecret: "{{ new_pullsecret_with_okd.stdout }}"
 
 - name: Generate an OpenSSL private key
   openssl_privatekey:

--- a/kubeinit/roles/kubeinit_registry/tasks/20_mirror_okd.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/20_mirror_okd.yml
@@ -13,7 +13,7 @@
 
     oc adm \
         release mirror \
-        --registry-config=./pullsecret.json \
+        --registry-config={{ kubeinit_registry_auth_file }} \
         --from={{ kubeinit_okd_registry }}/{{ kubeinit_okd_registry_organization }}/{{ kubeinit_okd_registry_repository }}:{{ kubeinit_okd_registry_release_tag }} \
         --to={{ kubeinit_registry_uri }}/{{ kubeinit_okd_registry_repository }} \
         --to-release-image={{ kubeinit_registry_uri }}/{{ kubeinit_okd_registry_repository }}:{{ kubeinit_okd_registry_release_tag }} \
@@ -21,7 +21,7 @@
 
     oc adm \
         release extract \
-        --registry-config=./pullsecret.json \
+        --registry-config={{ kubeinit_registry_auth_file }} \
         --command=openshift-install "{{ kubeinit_registry_uri }}/{{ kubeinit_okd_registry_repository }}:{{ kubeinit_okd_registry_release_tag }}"
 
     # This will override the current installer binary


### PR DESCRIPTION
This patch appends the disconnected install auth token
to the pullsecrets variable so its added to the pullSecret
install-config variable when deploying the OKD cluster.