### PR TITLE
fix: include --image-override in the submariner playbook

### DIFF
--- a/kubeinit/roles/kubeinit_submariner/tasks/10_join_clusters.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/10_join_clusters.yml
@@ -86,7 +86,7 @@
 - name: "Join cluster to the broker"
   shell: |
     export PATH=$PATH:~/.local/bin
-    subctl join --kubeconfig ~/.kube/config ./broker-info.subm --servicecidr {{ kubeinit_inventory_cluster_service_cidr }} --no-label --disable-nat --enable-pod-debugging --cable-driver libreswan --clusterid {{ kubeinit_inventory_cluster_name }} # --image-override=quay.io/submariner/submariner-operator:devel
+    subctl join --kubeconfig ~/.kube/config ./broker-info.subm --servicecidr {{ kubeinit_inventory_cluster_service_cidr }} --no-label --disable-nat --enable-pod-debugging --cable-driver libreswan --clusterid {{ kubeinit_inventory_cluster_name }} --image-override=quay.io/submariner/submariner-operator:devel
   args:
     executable: /bin/bash
   register: join_cluster


### PR DESCRIPTION
This patch makes fully usable the submariner job and the
CI deployment.