### PR TITLE
fix: remove quotes from eof

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -40,14 +40,18 @@ git log -n 5 --pretty=oneline
 # Here we might define some different
 # variables depending on the scenario
 if [[ "$DISTRO" == "okd" && "$DRIVER" == "libvirt" ]]; then
-sudo tee scenario_variables.yml > /dev/null <<'EOF'
+sudo tee scenario_variables.yml > /dev/null <<EOF
 kubeinit_libvirt_test_variable1: example_var
 EOF
 else
-sudo tee scenario_variables.yml > /dev/null <<'EOF'
+sudo tee scenario_variables.yml > /dev/null <<EOF
 kubeinit_libvirt_test_variable2: example_var2
 EOF
 fi
+
+echo "The content of the scenario_variables.yml file is:"
+
+cat scenario_variables.yml
 
 # By default we deploy 3 master and 1 worker cluster
 # the case of 3 master is already by default

--- a/ci/run_submariner.sh
+++ b/ci/run_submariner.sh
@@ -34,9 +34,11 @@ cd kubeinit
 # git fetch ccamacho
 # git cherry-pick 58f718a29d5611234304b1e144a69
 
-sudo tee scenario_variables.yml > /dev/null <<'EOF'
+sudo tee scenario_variables.yml > /dev/null <<EOF
 kubeinit_submariner_test_pr_url: "https://github.com/submariner-io/submariner-operator/pull/$PULL_REQUEST"
 EOF
+
+echo "The content of the scenario_variables.yml file is:"
 
 cat scenario_variables.yml
 

--- a/kubeinit/roles/kubeinit_submariner/tasks/10_join_clusters.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/10_join_clusters.yml
@@ -86,7 +86,7 @@
 - name: "Join cluster to the broker"
   shell: |
     export PATH=$PATH:~/.local/bin
-    subctl join --kubeconfig ~/.kube/config ./broker-info.subm --servicecidr {{ kubeinit_inventory_cluster_service_cidr }} --no-label --disable-nat --enable-pod-debugging --cable-driver libreswan --clusterid {{ kubeinit_inventory_cluster_name }} --image-override=quay.io/submariner/submariner-operator:devel
+    subctl join --kubeconfig ~/.kube/config ./broker-info.subm --servicecidr {{ kubeinit_inventory_cluster_service_cidr }} --no-label --disable-nat --enable-pod-debugging --cable-driver libreswan --clusterid {{ kubeinit_inventory_cluster_name }} --image-override='submariner-operator=quay.io/submariner/submariner-operator:devel'
   args:
     executable: /bin/bash
   register: join_cluster


### PR DESCRIPTION
Quotes in OEF blocks variable expansion which is the
default behavior inside of here-docs.
This was disabled by quoting the label (with single or double quotes).