### PR TITLE
fix: pull from local registry explicitly

### DIFF
--- a/ci/launch_submariner_operator.py
+++ b/ci/launch_submariner_operator.py
@@ -29,6 +29,7 @@ def main():
     """Run the main method."""
     for branch in branches:
         for pr in repo.get_pulls(state='open', sort='created', base=branch.name):
+            labels = [item.name for item in pr.labels]
 
             sha = pr.head.sha
             committer_email = repo.get_commit(sha=sha).commit.committer.email
@@ -40,7 +41,7 @@ def main():
             #
             # Charmed Distribution of Kubernetes
             #
-            if ("feat: add image-override flag to subctl command" in pr.title):
+            if ("check-okd-rke" in labels):
                 distro = "multiple"
                 driver = "libvirt"
                 master = "1"

--- a/kubeinit/hosts/okd/inventory
+++ b/kubeinit/hosts/okd/inventory
@@ -13,7 +13,7 @@ kubeinit_inventory_network_net=10.0.0.0
 kubeinit_inventory_network_name=kimgtnet0
 kubeinit_inventory_network_bridge=kimgtbr0
 # external network variables
-kubeinit_inventory_network_bridge_external=kiextbr1
+kubeinit_inventory_network_bridge_external=kiextbr0
 kubeinit_inventory_network_bridge_external_dev=eth1
 kubeinit_inventory_network_bridge_external_ip=10.19.41.157
 kubeinit_inventory_network_bridge_external_gateway=10.19.41.254

--- a/kubeinit/roles/kubeinit_submariner/tasks/00_configure_common.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/00_configure_common.yml
@@ -96,16 +96,34 @@
     target: bin/subctl
   when: kubeinit_submariner_is_broker|bool or kubeinit_submariner_is_secondary|bool
 
+# We need this in both cluster and there are 2 different registries (1 per cluster)
 - name: "Make build"
   make:
     chdir: ~/submariner-operator
     target: build
   when: kubeinit_submariner_is_broker|bool or kubeinit_submariner_is_secondary|bool
 
+# We need this in both cluster and there are 2 different registries (1 per cluster)
 - name: "Make images"
   make:
     chdir: ~/submariner-operator
     target: images
+  when: kubeinit_submariner_is_broker|bool or kubeinit_submariner_is_secondary|bool
+
+# We need this in both cluster and there are 2 different registries (1 per cluster)
+- name: "Push the image to the local registry"
+  shell: |
+    set -o pipefail
+    set -e
+    LOCAL_REGISTRY=$(cat ~/registry-auths.json | jq .auths | jq -r 'keys[]')
+    docker tag quay.io/submariner/submariner-operator:devel $LOCAL_REGISTRY/submariner/submariner-operator:devel;
+    cp registry-auths.json ~/config.json
+    # --config will search the config.json in ~/
+    docker --config ~/ push $LOCAL_REGISTRY/submariner/submariner-operator:devel;
+  args:
+    executable: /bin/bash
+  register: push_submariner_to_local_registry
+  changed_when: "push_submariner_to_local_registry.rc == 0"
   when: kubeinit_submariner_is_broker|bool or kubeinit_submariner_is_secondary|bool
 
 - name: "Make the subctl binary available"

--- a/kubeinit/roles/kubeinit_submariner/tasks/10_join_clusters.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/10_join_clusters.yml
@@ -85,8 +85,12 @@
 
 - name: "Join cluster to the broker"
   shell: |
+    set -o pipefail
+    set -e
+
     export PATH=$PATH:~/.local/bin
-    subctl join --kubeconfig ~/.kube/config ./broker-info.subm --servicecidr {{ kubeinit_inventory_cluster_service_cidr }} --no-label --disable-nat --enable-pod-debugging --cable-driver libreswan --clusterid {{ kubeinit_inventory_cluster_name }} --image-override='submariner-operator=quay.io/submariner/submariner-operator:devel'
+    LOCAL_REGISTRY=$(cat ~/registry-auths.json | jq .auths | jq -r 'keys[]')
+    subctl join --kubeconfig ~/.kube/config ./broker-info.subm --servicecidr {{ kubeinit_inventory_cluster_service_cidr }} --no-label --disable-nat --enable-pod-debugging --cable-driver libreswan --clusterid {{ kubeinit_inventory_cluster_name }} --image-override="submariner-operator=$LOCAL_REGISTRY/submariner/submariner-operator:devel"
   args:
     executable: /bin/bash
   register: join_cluster


### PR DESCRIPTION
When deploying submariner the newly created
container images need to be tagged and pointed
to the local registry.