### PR TITLE
fix: allow docker and podman in the local registry container

### DIFF
--- a/kubeinit/roles/kubeinit_registry/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_registry/defaults/main.yml
@@ -23,6 +23,9 @@ kubeinit_registry_hide_sensitive_logs: true
 
 kubeinit_registry_enabled: true
 
+kubeinit_registry_container_engine: docker
+#kubeinit_registry_container_engine: podman
+
 kubeinit_registry_user: registryusername
 kubeinit_registry_password: registrypassword
 kubeinit_registry_email: example@domain.com
@@ -33,9 +36,9 @@ kubeinit_registry_email: example@domain.com
 kubeinit_registry_pullsecret: '  { "auths": {} }'
 
 kubeinit_registry_required_packages_aux: "{% if ( kubeinit_inventory_cluster_distro == 'rke' or kubeinit_inventory_cluster_distro == 'cdk' ) %}
-                                            podman, python3, python3-dns, jq, apache2-utils, skopeo
+                                            python3, python3-dns, jq, apache2-utils, skopeo
                                           {% else %}
-                                            podman, python3, python3-dns, jq, httpd-tools, skopeo
+                                            python3, python3-dns, jq, httpd-tools, skopeo
                                           {% endif %}"
 kubeinit_registry_required_packages: "{{ kubeinit_registry_required_packages_aux.split(',') }}"
 

--- a/kubeinit/roles/kubeinit_registry/tasks/00_install.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/00_install.yml
@@ -35,6 +35,12 @@
     state: present
     name: "{{ kubeinit_registry_required_packages | default([]) }}"
 
+- name: Install podman if required
+  package:
+    state: present
+    name: "podman"
+  when: kubeinit_registry_container_engine == 'podman'
+
 - name: Podman login to docker.io
   shell: |
     podman login docker.io \
@@ -44,7 +50,67 @@
     executable: /bin/bash
   register: podman_login
   changed_when: "podman_login.rc == 0"
-  when: kubeinit_inventory_cluster_distro == 'k8s' or kubeinit_inventory_cluster_distro == 'okd'
+  when: kubeinit_registry_container_engine == 'podman' and kubeinit_common_docker_username is defined and kubeinit_common_docker_password is defined
+
+- name: Install docker if required and distro is CentOS and we need docker in the registry
+  shell: |
+    yum install -y yum-utils
+    # Make sure podman is out
+    yum remove -y buildah podman cockpit-podman toolbox
+    yum remove -y docker \
+                  docker-client \
+                  docker-client-latest \
+                  docker-common \
+                  docker-latest \
+                  docker-latest-logrotate \
+                  docker-logrotate \
+                  docker-engine
+    yum-config-manager \
+        --add-repo \
+        https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y docker-ce docker-ce-cli containerd.io
+    systemctl start docker
+    systemctl enable docker
+  args:
+    executable: /bin/bash
+  register: docker_reg_install
+  changed_when: "docker_reg_install.rc == 0"
+  when: (kubeinit_registry_container_engine == 'docker') and (kubeinit_inventory_cluster_distro == 'k8s' or kubeinit_inventory_cluster_distro == 'okd')
+
+- name: Install docker if required and distro is Ubuntu and we need docker in the registry
+  shell: |
+    set -o pipefail
+    sudo apt-get remove docker docker-engine docker.io containerd runc
+    sudo apt-get update -y
+    sudo apt-get install -y \
+      apt-transport-https \
+      ca-certificates \
+      curl \
+      gnupg-agent \
+      software-properties-common
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+    #sudo add-apt-repository -y \
+    #   "deb [arch=arm64] https://download.docker.com/linux/ubuntu \
+    #   $(lsb_release -cs) \
+    #   stable"
+
+    # TODO:FIXME:Remove when the packages are available for groovy
+    sudo add-apt-repository -y \
+       "deb [arch=arm64] https://download.docker.com/linux/ubuntu \
+       bionic \
+       stable"
+
+    sudo apt-get update -y
+    sudo apt-get install docker-ce docker-ce-cli containerd.io -y
+
+    systemctl start docker
+    systemctl enable docker
+  args:
+    executable: /bin/bash
+  register: docker_reg_install
+  changed_when: "docker_reg_install.rc == 0"
+  when: (kubeinit_registry_container_engine == 'docker') and (kubeinit_inventory_cluster_distro == 'cdk' or kubeinit_inventory_cluster_distro == 'rke')
 
 - name: Make sure the python bindings are installed
   shell: |
@@ -54,13 +120,13 @@
     executable: /bin/bash
   register: install_python_docker_bindings
   changed_when: "install_python_docker_bindings.rc == 0"
-  when: kubeinit_inventory_cluster_distro == 'rke' or kubeinit_inventory_cluster_distro == 'cdk'
+  when: kubeinit_registry_container_engine == 'docker'
 
 - name: Log into DockerHub
   community.general.docker_login:
     username: "{{ kubeinit_common_docker_username | default(omit) }}"
     password: "{{ kubeinit_common_docker_password | default(omit) }}"
-  when: kubeinit_inventory_cluster_distro == 'rke' or kubeinit_inventory_cluster_distro == 'cdk'
+  when: kubeinit_registry_container_engine == 'docker' and kubeinit_common_docker_username is defined and kubeinit_common_docker_password is defined
 
 - name: Create directory to hold the registry files
   file:

--- a/kubeinit/roles/kubeinit_registry/tasks/10_configure.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/10_configure.yml
@@ -184,7 +184,7 @@
   become: true
   when: kubeinit_inventory_cluster_distro == 'rke' or kubeinit_inventory_cluster_distro == 'cdk'
 
-- name: Create container to serve the registry
+- name: Create a podman container to serve the registry
   containers.podman.podman_container:
     name: "{{ kubeinit_registry_pod_name }}"
     image: docker.io/library/registry:2
@@ -204,12 +204,47 @@
       REGISTRY_HTTP_TLS_CERTIFICATE: certs/domain.crt
       REGISTRY_HTTP_TLS_KEY: certs/domain.key
       REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED: true
-  register: registry_container_info
+  register: registry_podman_container_info
+  when: kubeinit_registry_container_engine == 'podman'
 
-- name: Setting facts about the container that will run the registry
+- name: Create a docker container to serve the registry
+  community.general.docker_container:
+    name: "{{ kubeinit_registry_pod_name }}"
+    image: docker.io/library/registry:2
+    pid_mode: host
+    state: started
+    # state: stopped
+    ports:
+        - "{{ kubeinit_registry_port }}:{{ kubeinit_registry_port }}"
+    volumes:
+      - "{{ kubeinit_registry_directory_data }}:/var/lib/registry:z"
+      - "{{ kubeinit_registry_directory_auth }}:/auth:z"
+      - "{{ kubeinit_registry_directory_cert }}:/certs:z"
+    env:
+      REGISTRY_AUTH: htpasswd
+      REGISTRY_AUTH_HTPASSWD_REALM: Registry
+      REGISTRY_HTTP_SECRET: ALongRandomSecretForRegistry
+      REGISTRY_AUTH_HTPASSWD_PATH: auth/htpasswd
+      REGISTRY_HTTP_TLS_CERTIFICATE: certs/domain.crt
+      REGISTRY_HTTP_TLS_KEY: certs/domain.key
+      REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED: "true"
+  register: registry_docker_container_info
+  when: kubeinit_registry_container_engine == 'docker'
+
+- name: Setting Podman facts about the container that will run the registry
   set_fact:
-    container_registry_name: "{{ registry_container_info.container.Name }}"
-    container_registry_pidfile: "{{ registry_container_info.container.ConmonPidFile }}"
+    container_registry_name: "{{ registry_podman_container_info.container.Name }}"
+    container_registry_pidfile: "{{ registry_podman_container_info.container.ConmonPidFile }}"
+  when: kubeinit_registry_container_engine == 'podman'
+
+- debug:
+    var: registry_docker_container_info
+  when: kubeinit_registry_container_engine == 'docker'
+
+- name: Setting Docker facts about the container that will run the registry
+  set_fact:
+    container_registry_id: "{{ registry_docker_container_info.ansible_facts.docker_container.Id }}"
+  when: kubeinit_registry_container_engine == 'docker'
 
 - name: Ensure user specific systemd instance are persistent
   command: |
@@ -225,7 +260,7 @@
     group: "{{ ansible_user }}"
     mode: '0775'
 
-- name: Copy the systemd service file
+- name: Copy the podman systemd service file
   copy:
     content: |
       [Unit]
@@ -243,6 +278,25 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: '0644'
+  when: kubeinit_registry_container_engine == 'podman'
+
+#TODO:FIXME:This needs to be a systemctl service
+# - name: Copy the Docker systemd service file
+#   copy:
+#     content: |
+#       [Unit]
+#       Description=Docker container-registry.service
+#       [Service]
+#       Restart=on-failure
+#       ExecStop=/usr/bin/docker stop kubeinit-registry
+#       ExecStart=/usr/bin/docker start {{ container_registry_id }}
+#       [Install]
+#       WantedBy=default.target
+#     dest: "{{ ansible_user_dir }}/.config/systemd/user/container-registry.service"
+#     owner: "{{ ansible_user }}"
+#     group: "{{ ansible_user }}"
+#     mode: '0644'
+#   when: kubeinit_registry_container_engine == 'docker'
 
 - name: Reload systemd service
   systemd:
@@ -250,6 +304,7 @@
     scope: user
   environment:
     DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
+  when: kubeinit_registry_container_engine == 'podman'
 
 - name: Enable container-registry.service
   systemd:
@@ -258,6 +313,7 @@
     scope: user
   environment:
     DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
+  when: kubeinit_registry_container_engine == 'podman'
 
 - name: Start container-registry.service
   systemd:
@@ -266,6 +322,7 @@
     scope: user
   environment:
     DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
+  when: kubeinit_registry_container_engine == 'podman'
 
 - name: Read in the contents of domain.crt
   slurp:

--- a/kubeinit/roles/kubeinit_submariner/tasks/00_configure_common.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/00_configure_common.yml
@@ -14,34 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-#
-# Install docker-cli and run docker from a container
-# in the service machine
-#
-# We need to support docker as submariner wont work with podman
-- name: "Install docker-ce in the OKD service machine"
-  shell: |
-    yum install -y yum-utils
-    yum remove -y docker \
-                  docker-client \
-                  docker-client-latest \
-                  docker-common \
-                  docker-latest \
-                  docker-latest-logrotate \
-                  docker-logrotate \
-                  docker-engine
-    yum-config-manager \
-        --add-repo \
-        https://download.docker.com/linux/centos/docker-ce.repo
-    # We only use the docker-cli
-    yum install -y docker-ce-cli
-    podman run --privileged -p 12375:2375 -e DOCKER_TLS_CERTDIR="" -d docker:dind
-    DOCKER_HOST=tcp://localhost:12375 podman ps
-    DOCKER_HOST=tcp://localhost:12375 docker ps
-  register: install_okd_service_dockerce
-  changed_when: "install_okd_service_dockerce.rc == 0"
-  when: kubeinit_inventory_cluster_distro == "okd"
-
 - name: "Remove repo file"
   shell: |
     set -o pipefail


### PR DESCRIPTION
This patch allows choosing between docker or podman in the
service machine when installing the local registry.