### PR TITLE
chore: release 0.6.2

### DIFF
--- a/docs/src/usage.rst
+++ b/docs/src/usage.rst
@@ -68,7 +68,8 @@ Running from a release
 
 .. code-block:: console
 
-    TAG=0.6.1
+    # Get the latest release tag
+    TAG=$(curl --silent "https://api.github.com/repos/kubeinit/kubeinit/releases/latest" | jq -r .tag_name)
     podman run --rm -it \
         -v ~/.ssh/id_rsa:/root/.ssh/id_rsa:z \
         -v /etc/hosts:/etc/hosts \

--- a/kubeinit/README.md
+++ b/kubeinit/README.md
@@ -112,7 +112,8 @@ podman run --rm -it \
 ### Running from a release
 
 ```
-TAG=0.6.1
+# Get latest release tag name
+TAG=$(curl --silent "https://api.github.com/repos/kubeinit/kubeinit/releases/latest" | jq -r .tag_name)
 podman run --rm -it \
     -v ~/.ssh/id_rsa:/root/.ssh/id_rsa:z \
     -v /etc/hosts:/etc/hosts \

--- a/kubeinit/galaxy.yml
+++ b/kubeinit/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: kubeinit
 name: kubeinit
-version: 0.6.1
+version: 0.6.2
 readme: README.md
 authors:
   - Carlos Camacho <carloscamachoucv@gmail.com>

--- a/kubeinit/roles/kubeinit_registry/tasks/20_mirror_rke.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/20_mirror_rke.yml
@@ -3,6 +3,23 @@
   shell: |
     set -o pipefail
     set -e
+    mkdir -p /etc/containers/
+    cat << EOF > /etc/containers/policy.json
+    {
+        "default": [
+            {
+                "type": "insecureAcceptAnything"
+            }
+        ],
+        "transports":
+            {
+                "docker-daemon":
+                    {
+                        "": [{"type":"insecureAcceptAnything"}]
+                    }
+            }
+    }
+    EOF
     skopeo sync \
         --src docker \
         --dest docker docker.io/{{ item }} \


### PR DESCRIPTION
This patch releases 0.6.2 fix a major fix
for the new podman version breaking all distros
deployments.