### PR TITLE
fix: add workarounds for 1 master OKD cluster

### DIFF
--- a/kubeinit/roles/kubeinit_okd/tasks/30_post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/30_post_deployment_tasks.yml
@@ -85,6 +85,10 @@
     oc scale --replicas=1 deployment.apps/thanos-querier -n openshift-monitoring || true
     oc scale --replicas=1 statefulset.apps/prometheus-k8s -n openshift-monitoring || true
     oc scale --replicas=1 statefulset.apps/alertmanager-main -n openshift-monitoring || true
+
+    oc patch etcd cluster -p='{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}' --type=merge
+    oc patch authentications.operator.openshift.io cluster -p='{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableOAuthServer": true}}}' --type=merge
+
   args:
     executable: /bin/bash
   register: single_node_cluster


### PR DESCRIPTION
There are some missing parameters that
needs to be adjusted in OKD 4.6 to deploy
single node clusters.