### PR TITLE
fix: openshift sdk is not required

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,7 +1,6 @@
 pyyaml
 requests
 ansible
-openshift
 j2cli
 jinja2
 kubernetes


### PR DESCRIPTION
This patch removes the openshift requirement which is
not necesary.