### PR TITLE
fix: make sure libvirtd is enabled

### DIFF
--- a/kubeinit/roles/kubeinit_eks/tasks/30_configure_worker_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/30_configure_worker_nodes.yml
@@ -87,14 +87,6 @@
       changed_when: false
       when: groups['eks_worker_nodes'] | length > 0
 
-    - name: Label node
-      shell: |
-       kubectl label node {{ kubeinit_deployment_node_name }}.{{ kubeinit_inventory_cluster_domain }} node-role.kubernetes.io/worker=
-      changed_when: false
-      when: groups['eks_worker_nodes'] | length > 0
-      # The kubeconfig file is in the master nodes otherwise we can not relabel
-      delegate_to: "{{ groups['eks_master_nodes'][0] }}"
-
   delegate_to: "{{ kubeinit_deployment_node_name }}"
   tags:
     - provision_libvirt

--- a/kubeinit/roles/kubeinit_eks/tasks/40_post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/40_post_deployment_tasks.yml
@@ -35,6 +35,13 @@
         dest: ~/.kube/config
         mode: '0644'
 
+    - name: Label worker nodes
+      shell: |
+       kubectl label node {{ item }}.{{ kubeinit_inventory_cluster_domain }} node-role.kubernetes.io/worker=
+      changed_when: false
+      with_items:
+        - "{{ groups['all'] | map('regex_search','^.*(worker).*$') | select('string') | list }}"
+
     #
     # Configure NFS
     #

--- a/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
@@ -204,6 +204,12 @@
         state: latest
       register: upgraded_packages
 
+    - name: enable and start libvirtd
+      ansible.builtin.service:
+        name: libvirtd
+        enabled: yes
+        state: started
+
     - name: Restart if required
       set_fact:
          kubeinit_libvirt_restart: (installed_packages_debian.changed or installed_packages_centos.changed or upgraded_packages.changed)

--- a/kubeinit/roles/kubeinit_okd/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/main.yml
@@ -70,6 +70,8 @@
     kubeinit_deployment_role: bootstrap
   tags: provision_libvirt
 
+# 20_configure_cluster_nodes only checks for master nodes
+# check if possible to remove this as is skipped.
 - name: Configure the cluster bootstrap nodes
   include_role:
     name: "../../roles/kubeinit_okd"
@@ -126,6 +128,8 @@
     kubeinit_deployment_role: worker
   tags: provision_libvirt
 
+# 20_configure_cluster_nodes only checks for master nodes
+# check if possible to remove this as is skipped.
 - name: Configure the cluster worker nodes
   include_role:
     name: "../../roles/kubeinit_okd"

--- a/kubeinit/roles/kubeinit_validations/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_validations/defaults/main.yml
@@ -21,6 +21,10 @@
 kubeinit_validations_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 kubeinit_validations_hide_sensitive_logs: true
 
+# The validation will fail if the libvirt path is not found
 kubeinit_validations_libvirt_path: "/var/lib/libvirt"
+# If libvirt is not installed we will compare with the
+# space available in the parent folder.
+kubeinit_validations_libvirt_path_fallback: "/var/lib"
 kubeinit_validations_local_required_packages:
   - python3-netaddr

--- a/kubeinit/roles/kubeinit_validations/tasks/20_libvirt_free_space.yml
+++ b/kubeinit/roles/kubeinit_validations/tasks/20_libvirt_free_space.yml
@@ -22,7 +22,8 @@
 - name: Get libvirt hypervisors directory free space
   shell: |
     set -o pipefail
-    df -BG --output=avail {{ kubeinit_validations_libvirt_path }} | grep -v Avail
+    df -BG --output=avail {{ kubeinit_validations_libvirt_path }} | grep -v Avail 2> /dev/null || \
+    df -BG --output=avail {{ kubeinit_validations_libvirt_path_fallback }} | grep -v Avail 2> /dev/null
   register: kubeinit_validations_libvirt_free_space
   with_items:
     - "{{ groups['hypervisor_nodes'] | list }}"


### PR DESCRIPTION
By default libvirtd is not enabled
so the deployments might fail.

Also add a failsafe path for libvirt default
folder.