### PR TITLE
fix: allow not waiting for okd to converge

### DIFF
--- a/kubeinit/roles/kubeinit_okd/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_okd/defaults/main.yml
@@ -24,6 +24,8 @@ kubeinit_okd_hide_sensitive_logs: true
 kubeinit_okd_pod_cidr: 10.100.0.0/14
 kubeinit_okd_service_cidr: 172.30.0.0/16
 
+kubeinit_okd_wait_for_cluster_to_converge: False
+
 kubeinit_okd_registry: quay.io
 kubeinit_okd_registry_organization: openshift
 kubeinit_okd_registry_repository: okd

--- a/kubeinit/roles/kubeinit_okd/tasks/30_post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/30_post_deployment_tasks.yml
@@ -89,6 +89,7 @@
       delay: 20
       until: result.rc == 0
       changed_when: "result.rc == 0"
+      when: kubeinit_okd_wait_for_cluster_to_converge
 
     - name: "remove bootstrap node from haproxy"
       ansible.builtin.shell: |


### PR DESCRIPTION
This includes a variable to wait or not until
the cluster converges, mostly the autoupdate
can take more than 1 hour to finish.