### PR TITLE
chore: release 1.0.0

### DIFF
--- a/agent/setup.py
+++ b/agent/setup.py
@@ -28,7 +28,7 @@ if version_info < (3, 5):
 
 _NAME = 'kubeinit'
 _DESCRIPTION = 'The Kubeinit CLI'
-_REVISION = '0.6.5'
+_REVISION = '1.0.0'
 
 kubeinit_revision = os.environ.get('KUBEINIT_REVISION', "")
 if (kubeinit_revision != ""):

--- a/kubeinit/galaxy.yml
+++ b/kubeinit/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: kubeinit
 name: kubeinit
-version: 0.6.5
+version: 1.0.0
 readme: README.md
 authors:
   - Carlos Camacho <carloscamachoucv@gmail.com>

--- a/ui/app/version.py
+++ b/ui/app/version.py
@@ -16,4 +16,4 @@ License for the specific language governing permissions and limitations
 under the License.
 """
 
-__version__ = "0.6.5"
+__version__ = "1.0.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubeinit-ui",
-  "version": "0.6.5",
+  "version": "1.0.0",
   "description": "Kubeinit UI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR releases kubeinit 1.0.0
with mutiple features amongs them
support for 5 kubernetes distributions,
multicluster and multinode deployments.