### PR TITLE
fix: name check nodes correctly

### DIFF
--- a/kubeinit/roles/kubeinit_eks/tasks/20_configure_master_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/20_configure_master_nodes.yml
@@ -30,7 +30,7 @@
       changed_when: "install_all_certs_in_masters.rc == 0"
       become: true
       when: kubeinit_registry_enabled | bool
-      delegate_to: "{{ groups['eks_service_nodes'][0] }}"
+      delegate_to: "{{ hostvars[groups['eks_service_nodes'][0]].ansible_host }}"
 
     - name: Insert the local registry auth details
       ansible.builtin.shell: |

--- a/kubeinit/roles/kubeinit_eks/tasks/30_configure_worker_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/30_configure_worker_nodes.yml
@@ -37,7 +37,7 @@
       changed_when: "install_all_certs_in_workers.rc == 0"
       become: true
       when: kubeinit_registry_enabled | bool
-      delegate_to: "{{ groups['eks_service_nodes'][0] }}"
+      delegate_to: "{{ hostvars[groups['eks_service_nodes'][0]].ansible_host }}"
 
     - name: Insert the local registry auth details
       ansible.builtin.shell: |

--- a/kubeinit/roles/kubeinit_eks/tasks/40_post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/40_post_deployment_tasks.yml
@@ -21,7 +21,7 @@
         src: ~/.kube/config
       register: kubeinit_eks_cluster_kubeconfig
       # We fetch the kubeconfig from the first master node
-      delegate_to: "{{ groups['eks_master_nodes'][0] }}"
+      delegate_to: "{{ hostvars[groups['eks_master_nodes'][0]].ansible_host }}"
 
     - name: Create kube directory
       ansible.builtin.file:

--- a/kubeinit/roles/kubeinit_k8s/tasks/30_configure_worker_nodes.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/30_configure_worker_nodes.yml
@@ -47,7 +47,7 @@
       changed_when: false
       when: groups['k8s_worker_nodes'] | length > 0
       # The kubeconfig file is in the master nodes otherwise we can not relabel
-      delegate_to: "{{ groups['k8s_master_nodes'][0] }}"
+      delegate_to: "{{ hostvars[groups['k8s_master_nodes'][0]].ansible_host }}"
 
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
   tags:

--- a/kubeinit/roles/kubeinit_k8s/tasks/40_post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/40_post_deployment_tasks.yml
@@ -21,7 +21,7 @@
         src: ~/.kube/config
       register: kubeinit_k8s_cluster_kubeconfig
       # We fetch the kubeconfig from the first master node
-      delegate_to: "{{ groups['k8s_master_nodes'][0] }}"
+      delegate_to: "{{ hostvars[groups['k8s_master_nodes'][0]].ansible_host }}"
 
     - name: Create kube directory
       ansible.builtin.file:

--- a/kubeinit/roles/kubeinit_okd/tasks/20_check_nodes_ready.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/20_check_nodes_ready.yml
@@ -25,10 +25,6 @@
   retries: 60
   delay: 60
   until: cmd_res.stdout_lines | list | count == groups['okd_master_nodes'] | count
-  # Delegated to be executed in the service node but
-  # After the master nodes are deployed
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
-  # This should be only executed in master nodes
-  when: "'master' in kubeinit_deployment_role"
   tags:
     - provision_libvirt

--- a/kubeinit/roles/kubeinit_okd/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/main.yml
@@ -103,24 +103,6 @@
     kubeinit_deployment_role: bootstrap
   tags: provision_libvirt
 
-# 20_configure_cluster_nodes only checks for master nodes
-# check if possible to remove this as is skipped.
-- name: Configure the cluster bootstrap nodes
-  ansible.builtin.include_role:
-    name: "../../roles/kubeinit_okd"
-    tasks_from: 20_configure_cluster_nodes.yml
-    public: yes
-  # We always delegate this to the service node and
-  # check the deployment_role variable
-  with_items:
-    - "{{ groups['all'] | map('regex_search','^.*(service).*$') | select('string') | list }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    kubeinit_deployment_role: bootstrap
-  tags: provision_libvirt
-
 - name: Deploy the cluster master nodes
   ansible.builtin.include_role:
     name: "../../roles/kubeinit_libvirt"
@@ -138,7 +120,7 @@
 - name: Configure the cluster master nodes
   ansible.builtin.include_role:
     name: "../../roles/kubeinit_okd"
-    tasks_from: 20_configure_cluster_nodes.yml
+    tasks_from: 20_check_nodes_ready.yml
     public: yes
   # We always delegate this to the service node and
   # check the deployment_role variable
@@ -158,24 +140,6 @@
     public: yes
   with_items:
     - "{{ groups['all'] | map('regex_search','^.*(worker).*$') | select('string') | list }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    kubeinit_deployment_role: worker
-  tags: provision_libvirt
-
-# 20_configure_cluster_nodes only checks for master nodes
-# check if possible to remove this as is skipped.
-- name: Configure the cluster worker nodes
-  ansible.builtin.include_role:
-    name: "../../roles/kubeinit_okd"
-    tasks_from: 20_configure_cluster_nodes.yml
-    public: yes
-  # We always delegate this to the service node and
-  # check the deployment_role variable
-  with_items:
-    - "{{ groups['all'] | map('regex_search','^.*(service).*$') | select('string') | list }}"
   loop_control:
     loop_var: cluster_role_item
   vars:

--- a/kubeinit/roles/kubeinit_rke/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/10_configure_service_nodes.yml
@@ -63,7 +63,7 @@
         systemctl daemon-reload
         systemctl restart docker
       changed_when: false
-      delegate_to: "{{ item }}"
+      delegate_to: "{{ hostvars[item].ansible_host }}"
       with_items:
         - "{{ groups['all'] | map('regex_search','^(?!hypervisor)(?!.*service).*$') | select('string') | list }}"
       when: kubeinit_registry_enabled|bool


### PR DESCRIPTION
This PR renames correctly a task that checks that nodes are ready.