### PR TITLE
fix: add a wait for bootstrap to complete

### DIFF
--- a/kubeinit/roles/kubeinit_okd/tasks/25_wait_bootstrap_complete.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/25_wait_bootstrap_complete.yml
@@ -1,0 +1,26 @@
+---
+# Copyright kubeinit.com
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Wait for bootstrap to complete
+  ansible.builtin.command: openshift-install --dir=install_dir/ wait-for bootstrap-complete --log-level info
+  register: bootstrap_complete
+  retries: 5
+  delay: 20
+  until: bootstrap_complete.rc == 0
+  changed_when: "bootstrap_complete.rc == 0"
+  delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
+  tags:
+    - provision_libvirt

--- a/kubeinit/roles/kubeinit_okd/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/main.yml
@@ -129,6 +129,20 @@
     kubeinit_deployment_role: bootstrap
   tags: provision_libvirt
 
+- name: Wait for the bootstrap node to complete
+  ansible.builtin.include_role:
+    name: "../../roles/kubeinit_okd"
+    tasks_from: 25_wait_bootstrap_complete.yml
+    public: yes
+  with_items:
+    - "{{ groups['all'] | map('regex_search','^.*(service).*$') | select('string') | list }}"
+  loop_control:
+    loop_var: cluster_role_item
+  vars:
+    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    kubeinit_deployment_role: bootstrap
+  tags: provision_libvirt
+
 - name: Deploy the cluster master nodes
   ansible.builtin.include_role:
     name: "../../roles/kubeinit_libvirt"


### PR DESCRIPTION
This PR fixes a race condition when the master node
fails to start because the bootstrap node is not ready
to process requests.