### PR TITLE
fix: cleanup and configure ssh proxy once and wait for guest

### DIFF
--- a/kubeinit/roles/kubeinit_libvirt/tasks/00_cleanup.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/00_cleanup.yml
@@ -137,6 +137,17 @@
     ## Clean bastion config
     ##
 
+    - name: get the IP
+      become: no
+      delegate_to: localhost
+      ansible.builtin.command: hostname --ip-address
+      register: local_initiator_ip
+      changed_when: "local_initiator_ip.rc == 0"
+
+    - name: Set up the local IP
+      ansible.builtin.set_fact:
+        kubeinit_libvirt_initiator_ip={{ local_initiator_ip.stdout }}
+
     - name: clean bastion config
       become: no
       delegate_to: localhost
@@ -145,3 +156,9 @@
         rm -rf ~/.ssh/config.kubeinit
         sed -i '/Include config.kubeinit/d' ~/.ssh/config
       changed_when: false
+      # This should be executed only:
+      #(If the IP of the first hypervisor is different thant the IP of the machine triggering the playbook) and
+      #(If the first hypervisor is the current machine)
+      when: >
+        (hostvars[groups['hypervisor_nodes'][0]]['ansible_default_ipv4']['address'] not in kubeinit_libvirt_initiator_ip ) and
+        (groups['hypervisor_nodes'][0] in kubeinit_deployment_node_name)

--- a/kubeinit/roles/kubeinit_libvirt/tasks/10_k8s_deploy_nodes.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/10_k8s_deploy_nodes.yml
@@ -105,6 +105,15 @@
       register: virt_install
       changed_when: "virt_install.rc == 0"
 
+    - name: wait until {{ kubeinit_deployment_node_name }} is running
+      community.libvirt.virt:
+        command: list_vms
+        state: running
+      register: running_vms
+      retries: 30
+      delay: 10
+      until: kubeinit_deployment_node_name in running_vms.list_vms
+
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].target }}"
   tags:
     - provision_libvirt

--- a/kubeinit/roles/kubeinit_libvirt/tasks/10_okd_deploy_nodes.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/10_okd_deploy_nodes.yml
@@ -154,6 +154,15 @@
       changed_when: false
       when: "'master' in kubeinit_deployment_node_name or 'worker' in kubeinit_deployment_node_name or 'bootstrap' in kubeinit_deployment_node_name"
 
+    - name: wait until {{ kubeinit_deployment_node_name }} is running
+      community.libvirt.virt:
+        command: list_vms
+        state: running
+      register: running_vms
+      retries: 30
+      delay: 10
+      until: kubeinit_deployment_node_name in running_vms.list_vms
+
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].target }}"
   tags:
     - provision_libvirt

--- a/kubeinit/roles/kubeinit_libvirt/tasks/10_rke_deploy_nodes.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/10_rke_deploy_nodes.yml
@@ -102,6 +102,15 @@
       register: virt_install
       changed_when: "virt_install.rc == 0"
 
+    - name: wait until {{ kubeinit_deployment_node_name }} is running
+      community.libvirt.virt:
+        command: list_vms
+        state: running
+      register: running_vms
+      retries: 30
+      delay: 10
+      until: kubeinit_deployment_node_name in running_vms.list_vms
+
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].target }}"
   tags:
     - provision_libvirt

--- a/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
@@ -395,7 +395,12 @@
         chmod 644 ~/.ssh/config.kubeinit
         chmod 644 ~/.ssh/config
       changed_when: False
-      when: hostvars[groups['hypervisor_nodes'][0]]['ansible_default_ipv4']['address'] not in kubeinit_libvirt_initiator_ip
+      # This should be executed only:
+      #(If the IP of the first hypervisor is different thant the IP of the machine triggering the playbook) and
+      #(If the first hypervisor is the current machine)
+      when: >
+        (hostvars[groups['hypervisor_nodes'][0]]['ansible_default_ipv4']['address'] not in kubeinit_libvirt_initiator_ip ) and
+        (groups['hypervisor_nodes'][0] in kubeinit_deployment_node_name)
 
     - name: Create directories for config files per node
       ansible.builtin.file:


### PR DESCRIPTION
This PR makes sure we ssh proxy is configured once, also, cleaned
once in the first hypervisor.

Also makes sure each guest boots before continue, if we
create multiple guests at the same time libvirt may crash.