### PR TITLE
fix: move GitLab mirror to sw release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@
 # This job will execute a release:
 # Ansible galaxy new release
 # GitHub release with tag
+# Mirror to GitLab
 # Documents release
 name: release
 
@@ -60,6 +61,15 @@ jobs:
               python3 -m pip install --force dist/*
               kubeinit -v
           fi
+      - name: Mirror to GitLab
+        run: |
+          git clone https://github.com/Kubeinit/kubeinit.git kubeinit_mirror
+          cd kubeinit_mirror
+          git branch -r | grep -v -- ' -> ' | while read remote; do git branch --track "${remote#origin/}" "$remote" 2>&1 | grep -v ' already exists'; done
+          git fetch --all
+          git pull --all
+          sed -i 's/https:\/\/github\.com\/Kubeinit\/kubeinit\.git/https:\/\/github-access:${{ secrets.GITLAB_TOKEN }}@gitlab\.com\/kubeinit\/kubeinit.git/g' .git/config
+          git push --force --all origin
 
   release_docs:
     needs: release_sw
@@ -157,12 +167,3 @@ jobs:
           branch: gh-pages
           directory: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Mirror to GitLab
-        run: |
-          git clone https://github.com/Kubeinit/kubeinit.git kubeinit_mirror
-          cd kubeinit_mirror
-          git branch -r | grep -v '\->' | while read remote; do git branch --track "${remote#origin/}" "$remote"; done
-          git fetch --all
-          git pull --all
-          sed -i 's/https:\/\/github\.com\/Kubeinit\/kubeinit\.git/https:\/\/github-access:${{ secrets.GITLAB_TOKEN }}@gitlab\.com\/kubeinit\/kubeinit.git/g' .git/config
-          git push --force --all origin


### PR DESCRIPTION
This commit moves the repo sync to the correct place.