### PR TITLE
fix: fetching all branches returns 1 if they already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           git clone https://github.com/Kubeinit/kubeinit.git kubeinit_mirror
           cd kubeinit_mirror
-          git branch -r | grep -v -- ' -> ' | while read remote; do git branch --track "${remote#origin/}" "$remote" 2>&1 | grep -v ' already exists'; done
+          git branch -r | grep -v -- ' -> ' | while read remote; do git branch --track "${remote#origin/}" "$remote" 2>&1 | grep -v ' already exists'; done || true
           git fetch --all
           git pull --all
           sed -i 's/https:\/\/github\.com\/Kubeinit\/kubeinit\.git/https:\/\/github-access:${{ secrets.GITLAB_TOKEN }}@gitlab\.com\/kubeinit\/kubeinit.git/g' .git/config


### PR DESCRIPTION
This commit makes sure fetching the branches never returns 1.