### PR TITLE
fix: run bridge check only in the external host

### DIFF
--- a/kubeinit/roles/kubeinit_libvirt/tasks/00_ovn_post_setup.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/00_ovn_post_setup.yml
@@ -103,7 +103,7 @@
         # Create a logical router to connect the VMs switch
         #
         ovn-nbctl lr-add lr0
-        ovn-nbctl lrp-add lr0 lr0-sw0 00:00:00:65:77:09 {{ kubeinit_inventory_network_gateway }}/24
+        ovn-nbctl lrp-add lr0 lr0-sw0 00:00:00:65:77:09 {{ kubeinit_inventory_network_gateway }}/{{ kubeinit_inventory_network_cidr }}
         ovn-nbctl lsp-add sw0 sw0-lr0
         ovn-nbctl lsp-set-type sw0-lr0 router
         ovn-nbctl lsp-set-addresses sw0-lr0 router
@@ -154,13 +154,16 @@
         #
         sysctl net.ipv4.conf.all.rp_filter=2
         #
-        # NAT from eno1
+        # NAT from the external interface
         #
-        iptables -t nat -A POSTROUTING -s {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} -o eno1 -j MASQUERADE
+        # Get the external interface name
+        iface=$(ip route get "8.8.8.8" | grep -Po '(?<=(dev )).*(?= src| proto)')
         #
-        iptables -A FORWARD -i eno1 -j ACCEPT
+        iptables -t nat -A POSTROUTING -s {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} -o $iface -j MASQUERADE
+        #
+        iptables -A FORWARD -i $iface -j ACCEPT
         iptables -A FORWARD -i br-ex -j ACCEPT
-        iptables -A FORWARD -o eno1 -j ACCEPT
+        iptables -A FORWARD -o $iface -j ACCEPT
         iptables -A FORWARD -o br-ex -j ACCEPT
         #
         iptables -A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
@@ -35,7 +35,9 @@
         nmcli con show | grep {{ kubeinit_libvirt_external_service_interface.attached }}
       register: bridge_status
       ignore_errors: yes
-      when: kubeinit_libvirt_external_service_interface_enabled
+      when: |
+        (hostvars[ groups['all'] | map('regex_search','^.*service.*$') | select('string') | list | first ].target in kubeinit_deployment_node_name) and
+        kubeinit_libvirt_external_service_interface_enabled
 
     - name: Fail if bridge is not created but included
       ansible.builtin.fail:
@@ -43,8 +45,14 @@
           The bridge {{ kubeinit_libvirt_external_service_interface.attached }} to provide external
           connectivity is not created. This is a requirement that needs to be
           created before running the playbook.
+          You must create {{ kubeinit_libvirt_external_service_interface.attached }} in
+          {{ hostvars[ groups['all'] | map('regex_search','^.*service.*$') | select('string') | list | first ].target }}
+          before continue.
           Run `nmcli con show` and check it is created correctly.
-      when: kubeinit_libvirt_external_service_interface_enabled and bridge_status.stdout_lines | list | count == 0
+      when: |
+        (hostvars[ groups['all'] | map('regex_search','^.*service.*$') | select('string') | list | first ].target in kubeinit_deployment_node_name) and
+        kubeinit_libvirt_external_service_interface_enabled and
+        bridge_status.rc != 0
 
     - name: Fails if OS is not supported
       ansible.builtin.fail:


### PR DESCRIPTION
This PR checks that the external bridge is only
created in the node with the service node.