### PR TITLE
fix: move haproxy port to 9090 and disable ipv6

### DIFF
--- a/kubeinit/roles/kubeinit_cdk/tasks/00_bounce_packages.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/00_bounce_packages.yml
@@ -20,6 +20,18 @@
 
 - name: Configure common requirements in guests
   block:
+    - name: "Disable IPv6"
+      ansible.builtin.shell: |
+        set -o pipefail
+        # Disable IPv6
+        echo "net.ipv6.conf.all.disable_ipv6 = 1" > /etc/sysctl.d/70-ipv6.conf
+        echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.d/70-ipv6.conf
+        sysctl --load /etc/sysctl.d/70-ipv6.conf
+      args:
+        executable: /bin/bash
+      register: disable_ipv6
+      changed_when: "disable_ipv6.rc == 0"
+
     - name: Force apt-get update
       ansible.builtin.shell: |
         apt-get update

--- a/kubeinit/roles/kubeinit_eks/tasks/00_bounce_packages.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/00_bounce_packages.yml
@@ -16,9 +16,22 @@
 
 - name: Configure the service node
   block:
+    - name: "Disable IPv6"
+      ansible.builtin.shell: |
+        set -o pipefail
+        # Disable IPv6
+        echo "net.ipv6.conf.all.disable_ipv6 = 1" > /etc/sysctl.d/70-ipv6.conf
+        echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.d/70-ipv6.conf
+        sysctl --load /etc/sysctl.d/70-ipv6.conf
+      args:
+        executable: /bin/bash
+      register: disable_ipv6
+      changed_when: "disable_ipv6.rc == 0"
+
     #
     # eks repos
     #
+
     - name: Remove repo before adding it
       ansible.builtin.file:
         path: /etc/yum.repos.d/kubernetes.repo

--- a/kubeinit/roles/kubeinit_haproxy/templates/haproxy.cfg.j2
+++ b/kubeinit/roles/kubeinit_haproxy/templates/haproxy.cfg.j2
@@ -40,7 +40,7 @@ defaults
     maxconn                 20000
 
 listen stats
-    bind :9000
+    bind :9090
     mode http
     stats enable
     stats uri /

--- a/kubeinit/roles/kubeinit_k8s/tasks/00_bounce_packages.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/00_bounce_packages.yml
@@ -16,6 +16,18 @@
 
 - name: Configure the service node
   block:
+    - name: "Disable IPv6"
+      ansible.builtin.shell: |
+        set -o pipefail
+        # Disable IPv6
+        echo "net.ipv6.conf.all.disable_ipv6 = 1" > /etc/sysctl.d/70-ipv6.conf
+        echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.d/70-ipv6.conf
+        sysctl --load /etc/sysctl.d/70-ipv6.conf
+      args:
+        executable: /bin/bash
+      register: disable_ipv6
+      changed_when: "disable_ipv6.rc == 0"
+
     #
     # k8s repos
     #

--- a/kubeinit/roles/kubeinit_okd/tasks/00_bounce_packages.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/00_bounce_packages.yml
@@ -16,6 +16,18 @@
 
 - name: Configure the service node
   block:
+    - name: "Disable IPv6"
+      ansible.builtin.shell: |
+        set -o pipefail
+        # Disable IPv6
+        echo "net.ipv6.conf.all.disable_ipv6 = 1" > /etc/sysctl.d/70-ipv6.conf
+        echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.d/70-ipv6.conf
+        sysctl --load /etc/sysctl.d/70-ipv6.conf
+      args:
+        executable: /bin/bash
+      register: disable_ipv6
+      changed_when: "disable_ipv6.rc == 0"
+
     - name: update packages
       ansible.builtin.yum:
         name: "*"

--- a/kubeinit/roles/kubeinit_rke/tasks/00_bounce_packages.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/00_bounce_packages.yml
@@ -20,6 +20,18 @@
 
 - name: Configure common requirements in guests
   block:
+    - name: "Disable IPv6"
+      ansible.builtin.shell: |
+        set -o pipefail
+        # Disable IPv6
+        echo "net.ipv6.conf.all.disable_ipv6 = 1" > /etc/sysctl.d/70-ipv6.conf
+        echo "net.ipv6.conf.default.disable_ipv6 = 1" >> /etc/sysctl.d/70-ipv6.conf
+        sysctl --load /etc/sysctl.d/70-ipv6.conf
+      args:
+        executable: /bin/bash
+      register: disable_ipv6
+      changed_when: "disable_ipv6.rc == 0"
+
     - name: Force apt-get update
       ansible.builtin.shell: |
         apt-get update


### PR DESCRIPTION
This commit shifts the default 9000 port to
9090 because it might conflict with the default
cockpit port and disables ipv6 by default in
the guests.