### PR TITLE
fix: backup install manifests

### DIFF
--- a/kubeinit/roles/kubeinit_okd/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/10_configure_service_nodes.yml
@@ -222,6 +222,8 @@
 
     - name: "Render ignition files"
       ansible.builtin.shell: |
+        # We backup first the manifests
+        tar -czvf install_manifests_backup.tar.gz ~/install_dir/
         openshift-install create ignition-configs --dir=install_dir/
         cp -R install_dir/* /var/www/html/okd4/
       register: render_ignition_files

--- a/kubeinit/roles/kubeinit_okd/tasks/30_check_bootstrap_complete.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/30_check_bootstrap_complete.yml
@@ -25,6 +25,7 @@
       delay: 20
       until: result.rc == 0
       changed_when: "result.rc == 0"
+      when: groups['okd_master_nodes'] | length > 1
 
     - name: "remove bootstrap node from haproxy"
       ansible.builtin.shell: |


### PR DESCRIPTION
This commit store the install manifests
before rendering the ignition files for
having a better debugging.