### PR TITLE
fix: securize podman login

### DIFF
--- a/kubeinit/roles/kubeinit_apache/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_apache/tasks/main.yml
@@ -48,10 +48,10 @@
 - name: Podman login to docker.io
   ansible.builtin.shell: |
     podman login docker.io \
-      --username {{ kubeinit_common_docker_username }} \
-      --password {{ kubeinit_common_docker_password }}
+      --username {{ kubeinit_common_docker_username }} --password-stdin
   args:
     executable: /bin/bash
+    stdin: "{{ kubeinit_common_docker_password }}"
   register: podman_login
   changed_when: "podman_login.rc == 0"
   when: |

--- a/kubeinit/roles/kubeinit_bind/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_bind/tasks/main.yml
@@ -89,10 +89,10 @@
 - name: Podman login to docker.io
   ansible.builtin.shell: |
     podman login docker.io \
-      --username {{ kubeinit_common_docker_username }} \
-      --password {{ kubeinit_common_docker_password }}
+      --username {{ kubeinit_common_docker_username }} --password-stdin
   args:
     executable: /bin/bash
+    stdin: "{{ kubeinit_common_docker_password }}"
   register: podman_login
   changed_when: "podman_login.rc == 0"
   when: |

--- a/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
@@ -54,10 +54,10 @@
 - name: Podman login to docker.io
   ansible.builtin.shell: |
     podman login docker.io \
-      --username {{ kubeinit_common_docker_username }} \
-      --password {{ kubeinit_common_docker_password }}
+      --username {{ kubeinit_common_docker_username }} --password-stdin
   args:
     executable: /bin/bash
+    stdin: "{{ kubeinit_common_docker_password }}"
   register: podman_login
   changed_when: "podman_login.rc == 0"
   when: |

--- a/kubeinit/roles/kubeinit_registry/tasks/00_install.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/00_install.yml
@@ -42,10 +42,10 @@
 - name: Podman login to docker.io
   ansible.builtin.shell: |
     podman login docker.io \
-      --username {{ kubeinit_common_docker_username }} \
-      --password {{ kubeinit_common_docker_password }}
+      --username {{ kubeinit_common_docker_username }} --password-stdin
   args:
     executable: /bin/bash
+    stdin: "{{ kubeinit_common_docker_password }}"
   register: podman_login
   changed_when: "podman_login.rc == 0"
   when: |


### PR DESCRIPTION
This patch fixes showing the podman login
password in the Ansible logs.