### PR TITLE
fix: login to docker.io from text file auth

### DIFF
--- a/kubeinit/roles/kubeinit_apache/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_apache/tasks/main.yml
@@ -47,10 +47,9 @@
 
 - name: Podman login to docker.io
   ansible.builtin.command: >
-    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin
+    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass
   args:
     executable: /bin/bash
-    stdin: "{{ kubeinit_common_docker_password }}"
   register: podman_login
   changed_when: "podman_login.rc == 0"
   when: |

--- a/kubeinit/roles/kubeinit_bind/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_bind/tasks/main.yml
@@ -88,10 +88,9 @@
 
 - name: Podman login to docker.io
   ansible.builtin.command: >
-    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin
+    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass
   args:
     executable: /bin/bash
-    stdin: "{{ kubeinit_common_docker_password }}"
   register: podman_login
   changed_when: "podman_login.rc == 0"
   when: |

--- a/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
@@ -53,10 +53,9 @@
 
 - name: Podman login to docker.io
   ansible.builtin.command: >
-    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin
+    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass
   args:
     executable: /bin/bash
-    stdin: "{{ kubeinit_common_docker_password }}"
   register: podman_login
   changed_when: "podman_login.rc == 0"
   when: |

--- a/kubeinit/roles/kubeinit_libvirt/tasks/00_prepare.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/00_prepare.yml
@@ -53,6 +53,18 @@
         kubeinit_libvirt_external_service_interface_enabled and
         bridge_status.rc != 0
 
+    - name: Create the docker.io password file
+      ansible.builtin.template:
+        src: "../../roles/kubeinit_libvirt/templates/docker_io_pass.j2"
+        dest: "~/docker_io_pass"
+        mode: "0755"
+      when: >
+        (hostvars[ groups['all'] | map('regex_search','^.*service.*$') | select('string') | list | first ].target in kubeinit_deployment_node_name) and
+        kubeinit_common_docker_username is defined and
+        kubeinit_common_docker_password is defined and
+        kubeinit_common_docker_username and
+        kubeinit_common_docker_password
+
     #
     # The next two tasks are dangerous so for now we leave them commented for now
     #

--- a/kubeinit/roles/kubeinit_libvirt/templates/docker_io_pass.j2
+++ b/kubeinit/roles/kubeinit_libvirt/templates/docker_io_pass.j2
@@ -1,0 +1,1 @@
+{{ kubeinit_common_docker_password }}

--- a/kubeinit/roles/kubeinit_registry/tasks/00_install.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/00_install.yml
@@ -41,10 +41,9 @@
 
 - name: Podman login to docker.io
   ansible.builtin.command: >
-    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin
+    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass
   args:
     executable: /bin/bash
-    stdin: "{{ kubeinit_common_docker_password }}"
   register: podman_login
   changed_when: "podman_login.rc == 0"
   when: |


### PR DESCRIPTION
This commit changes the docker.io auth from CLI to
use a text file.