### PR TITLE
fix: move to shell and sort parameters

### DIFF
--- a/kubeinit/roles/kubeinit_apache/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_apache/tasks/main.yml
@@ -57,8 +57,9 @@
     kubeinit_common_docker_password
 
 - name: Podman login to docker.io
-  ansible.builtin.command: >
-    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass
+  ansible.builtin.shell: |
+    set -o pipefail
+    podman login --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass docker.io
   args:
     executable: /bin/bash
   register: podman_login

--- a/kubeinit/roles/kubeinit_bind/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_bind/tasks/main.yml
@@ -98,8 +98,9 @@
     kubeinit_common_docker_password
 
 - name: Podman login to docker.io
-  ansible.builtin.command: >
-    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass
+  ansible.builtin.shell: |
+    set -o pipefail
+    podman login --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass docker.io
   args:
     executable: /bin/bash
   register: podman_login

--- a/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
@@ -63,8 +63,9 @@
     kubeinit_common_docker_password
 
 - name: Podman login to docker.io
-  ansible.builtin.command: >
-    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass
+  ansible.builtin.shell: |
+    set -o pipefail
+    podman login --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass docker.io
   args:
     executable: /bin/bash
   register: podman_login

--- a/kubeinit/roles/kubeinit_registry/tasks/00_install.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/00_install.yml
@@ -51,8 +51,9 @@
     kubeinit_common_docker_password
 
 - name: Podman login to docker.io
-  ansible.builtin.command: >
-    podman login docker.io --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass
+  ansible.builtin.shell: |
+    set -o pipefail
+    podman login --username {{ kubeinit_common_docker_username }} --password-stdin < ~/docker_io_pass docker.io
   args:
     executable: /bin/bash
   register: podman_login


### PR DESCRIPTION
This commit moves to shell the podman login
commands as the dont work correctly with
different OS distros.