### PR TITLE
fix: do not upgrade Docker

### DIFF
--- a/kubeinit/roles/kubeinit_rke/tasks/10_configure_common.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/10_configure_common.yml
@@ -33,13 +33,15 @@
         resize2fs /dev/vda1
       changed_when: false
 
-    - name: Install Docker
-      ansible.builtin.shell: |
-        apt-get update -y
-        apt-get remove docker docker-engine docker.io -y
-        apt-get install docker.io -y
-        docker --version
-      changed_when: false
+    # TODO:FIXME Docker is already installed
+    # add a default variable to pin the version. 
+    # - name: Install Docker
+    #   ansible.builtin.shell: |
+    #     apt-get update -y
+    #     apt-get remove docker docker-engine docker.io -y
+    #     apt-get install docker.io -y
+    #     docker --version
+    #   changed_when: false
 
     - name: Start and enable docker service
       ansible.builtin.service:


### PR DESCRIPTION
This commit removes the docker upgrade command,
we need to pin a specific version.