### PR TITLE
fix: adjust submariner labels based on the workers number

### DIFF
--- a/kubeinit/roles/kubeinit_submariner/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_submariner/defaults/main.yml
@@ -35,7 +35,7 @@ kubeinit_submariner_test_pr_id: ""
 
 kubeinit_submariner_created_images_list: []
 
-kubeinit_submariner_subctl_verify_operation_timeout: 10
-kubeinit_submariner_subctl_verify_connection_attempts: 1
-kubeinit_submariner_subctl_verify_connection_timeout: 20
-kubeinit_submariner_subctl_verify_only: "connectivity,service-discovery,gateway-failover"
+kubeinit_submariner_subctl_verify_operation_timeout: 600
+kubeinit_submariner_subctl_verify_connection_attempts: 20
+kubeinit_submariner_subctl_verify_connection_timeout: 600
+kubeinit_submariner_subctl_verify_only: "connectivity,service-discovery"

--- a/kubeinit/roles/kubeinit_submariner/tasks/00_broker_deployment.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/00_broker_deployment.yml
@@ -348,3 +348,15 @@
       changed_when: "kubeinit_submariner_get_files_from_broker.rc == 0"
       delegate_to: "hypervisor-01"
       when: kubeinit_submariner_is_broker|bool
+
+    - name: Tag the worker nodes
+      ansible.builtin.shell: |
+        KUBECONFIG=~/.kube/config kubectl label node {{ item }} submariner.io/gateway=true --overwrite
+        KUBECONFIG=~/.kube/config kubectl label node {{ item }} gateway.submariner.io/natt-discovery-port=4490 --overwrite
+      args:
+        executable: /bin/bash
+      register: tag_worker_broker
+      changed_when: "tag_worker_broker.rc == 0"
+      when: kubeinit_submariner_is_broker|bool
+      with_items:
+        - "{{ groups['all_worker_nodes'] | list }}"

--- a/kubeinit/roles/kubeinit_submariner/tasks/10_secondary_deployment.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/10_secondary_deployment.yml
@@ -122,7 +122,7 @@
         executable: /bin/bash
       register: install_subctl
       changed_when: "install_subctl.rc == 0"
-      when: kubeinit_submariner_is_broker|bool and kubeinit_submariner_deploy_stable|bool
+      when: kubeinit_submariner_is_secondary|bool and kubeinit_submariner_deploy_stable|bool
 
     - name: Append subctl path to profile
       ansible.builtin.lineinfile:
@@ -187,13 +187,14 @@
       changed_when: "join_cluster.rc == 0"
       when: kubeinit_submariner_is_secondary|bool and kubeinit_submariner_deploy_stable|bool
 
-    - name: Tag worker node
+    - name: Tag the worker nodes
       ansible.builtin.shell: |
         KUBECONFIG=~/.kube/config kubectl label node {{ item }} submariner.io/gateway=true --overwrite
+        KUBECONFIG=~/.kube/config kubectl label node {{ item }} gateway.submariner.io/natt-discovery-port=4490 --overwrite
       args:
         executable: /bin/bash
-      register: tag_worker_okd
-      changed_when: "tag_worker_okd.rc == 0"
-      when: kubeinit_submariner_is_secondary|bool or kubeinit_submariner_is_secondary|bool
+      register: tag_worker_sec
+      changed_when: "tag_worker_sec.rc == 0"
+      when: kubeinit_submariner_is_secondary|bool
       with_items:
         - "{{ groups['all_worker_nodes'] | list }}"

--- a/kubeinit/roles/kubeinit_submariner/tasks/20_check_connection.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/20_check_connection.yml
@@ -35,4 +35,4 @@
       register: subma_verify
       until: subma_verify.rc == 0
       changed_when: "subma_verify.rc == 0"
-      ignore_errors: True
+      when: kubeinit_submariner_is_secondary|bool

--- a/kubeinit/roles/kubeinit_submariner/tasks/30_subctl_verify.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/30_subctl_verify.yml
@@ -22,14 +22,11 @@
         set -e
         export PATH=$PATH:~/.local/bin
         subctl verify ~/kubeconfig_okd ~/kubeconfig_rke \
-            --verbose \
-            --enable-disruptive \
             --operation-timeout {{ kubeinit_submariner_subctl_verify_operation_timeout }} \
             --connection-attempts {{ kubeinit_submariner_subctl_verify_connection_attempts }} \
             --connection-timeout {{ kubeinit_submariner_subctl_verify_connection_timeout }} \
-            --only {{ kubeinit_submariner_subctl_verify_only }}
+            --only {{ kubeinit_submariner_subctl_verify_only }} {% if groups['all_worker_nodes'] | list | length > 1 %},gateway-failover --enable-disruptive {% endif %}
       args:
         executable: /bin/bash
       register: subma_subctl_verify
       changed_when: "subma_subctl_verify.rc == 0"
-      ignore_errors: True


### PR DESCRIPTION
This commit adds the correct nodes labels for
the submariner operator to work in HA when its
possible.