### PR TITLE
fix: change subctl--linux-amd64 with subctl

### DIFF
--- a/kubeinit/roles/kubeinit_submariner/tasks/00_broker_deployment.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/00_broker_deployment.yml
@@ -262,7 +262,7 @@
         docker save $IDS -o /tmp/submariner_images.tar
 
         # Backup the binary files
-        cp ~/submariner-operator/bin/subctl--linux-amd64 ~/subctl
+        cp ~/submariner-operator/bin/subctl ~/subctl
         tar -cvf /tmp/submariner_binaries.tar ~/subctl
       args:
         executable: /bin/bash


### PR DESCRIPTION
This commit changes subctl--linux-amd64 with
subctl--linux-amd64 because is the new name
for this binary.