### PR TITLE
feat: sleep for x seconds before the subctl verify.

### DIFF
--- a/kubeinit/roles/kubeinit_submariner/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_submariner/defaults/main.yml
@@ -35,7 +35,9 @@ kubeinit_submariner_test_pr_id: ""
 
 kubeinit_submariner_created_images_list: []
 
-kubeinit_submariner_subctl_verify_operation_timeout: 600
-kubeinit_submariner_subctl_verify_connection_attempts: 20
-kubeinit_submariner_subctl_verify_connection_timeout: 600
+kubeinit_submariner_subctl_verify_pre_sleep: true
+kubeinit_submariner_subctl_verify_pre_sleep_timeout: 300
+kubeinit_submariner_subctl_verify_operation_timeout: 1800
+kubeinit_submariner_subctl_verify_connection_attempts: 60
+kubeinit_submariner_subctl_verify_connection_timeout: 1800
 kubeinit_submariner_subctl_verify_only: "connectivity,service-discovery"

--- a/kubeinit/roles/kubeinit_submariner/tasks/30_subctl_verify.yml
+++ b/kubeinit/roles/kubeinit_submariner/tasks/30_subctl_verify.yml
@@ -16,6 +16,11 @@
 
 - name: Run the subctl verify tasks
   block:
+    - name: "Sleep for {{ kubeinit_submariner_subctl_verify_pre_sleep_timeout }} seconds until the cluster converges"
+      ansible.builtin.wait_for:
+        timeout: "{{ kubeinit_submariner_subctl_verify_pre_sleep_timeout }}"
+      when: kubeinit_submariner_subctl_verify_pre_sleep|bool
+
     - name: Execute subctl verify
       ansible.builtin.shell: |
         set -o pipefail


### PR DESCRIPTION
The CI triggers the subctl verify command
just after the cluster is deployed. Let's give
some time to the cluster to converge prior the test.