### PR TITLE
fix: make jobs to force use latest ubuntu and python 3.8

### DIFF
--- a/.github/workflows/docs_build_pr.yml
+++ b/.github/workflows/docs_build_pr.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.8]
     steps:
       - name: Use checkout v2 with all git log available
         uses: actions/checkout@v2

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -3,7 +3,7 @@ name: linters
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -3,7 +3,7 @@ name: molecule
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,10 @@ jobs:
   release_docs:
     needs: release_sw
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.8]
     steps:
       - name: Use checkout v2 with all git log available
         uses: actions/checkout@v2

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.8]
     steps:
     - uses: actions/stale@v3
       with:

--- a/ci/launch_e2e_periodic.py
+++ b/ci/launch_e2e_periodic.py
@@ -81,14 +81,14 @@ def main(distros):
         #
         # OVN multi HV deployment
         #
-        if ("okd.ovn-libvirt-3-master-2-worker-default" in labels):
+        if ("okd.ovn-libvirt-3-master-2-worker-default" == config):
             distro = "okd.ovn"
             driver = "libvirt"
             master = "3"
             worker = "2"
             execute = True
             scenario = "default"
-            remove_label("okd.ovn-libvirt-3-master-2-worker-default", pr, repo)
+
         #
         # Charmed Distribution of Kubernetes
         #


### PR DESCRIPTION
This commit adjust the GitHub jobs to use the
same status check (build 3.8).