### PR TITLE
fix: pull from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM docker.io/library/python:slim
 
 LABEL maintainer="Carlos Camacho <carloscamachoucv@gmail.com>"
 LABEL quay.expires-after=30w


### PR DESCRIPTION
By default we use python:slim
to deploy the kubeinit container.
This commit makes explicit where to
pull from.