### PR TITLE
Use /bin/bash when using set -o pipefail

### DIFF
--- a/kubeinit/roles/kubeinit_eks/tasks/30_configure_master_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/30_configure_master_nodes.yml
@@ -66,6 +66,8 @@
       ansible.builtin.shell: |
         set -o pipefail
         curl -v --silent --user {{ kubeinit_registry_user }}:{{ kubeinit_registry_password }} https://{{ kubeinit_registry_uri }}/v2/etcd/tags/list --stderr - | grep '"name":"etcd"' | jq .tags[0]
+      args:
+        executable: /bin/bash
       register: eks_etcd_tag
       changed_when: "eks_etcd_tag.rc == 0"
       when: groups['all_master_nodes'][0] in kubeinit_deployment_node_name
@@ -109,6 +111,8 @@
         #    --control-plane-endpoint "api.{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }}:6443" \
         #    --upload-certs \
         #    --pod-network-cidr={{ kubeinit_eks_pod_network_cidr }}
+      args:
+        executable: /bin/bash
       register: eks_master_kubeadm_master_init_output
       changed_when: "eks_master_kubeadm_master_init_output.rc == 0"
       when: groups['all_master_nodes'][0] in kubeinit_deployment_node_name

--- a/kubeinit/roles/kubeinit_libvirt/tasks/10_cleanup.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/10_cleanup.yml
@@ -99,6 +99,8 @@
         ssh-keygen -R  {{ hostvars[item].ansible_host }} || true
       with_items: "{{ groups['all_nodes'] }}"
       when: known_hosts_file.stat.exists | bool
+      args:
+        executable: /bin/bash
       register: libvirt_reset_ssh
       changed_when: "libvirt_reset_ssh.rc == 0"
 

--- a/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_coreos_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_coreos_guest.yml
@@ -96,6 +96,8 @@
             --disk size={{ hostvars[kubeinit_deployment_node_name].disk | replace('G','') }},readonly=false \
             --location {{ kubeinit_libvirt_target_image_dir }}/ \
             --extra-args "${kernel_args}"
+      args:
+        executable: /bin/bash
       changed_when: false
 
     - name: wait until {{ kubeinit_deployment_node_name }} is running

--- a/kubeinit/roles/kubeinit_nexus/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_nexus/tasks/main.yml
@@ -54,6 +54,8 @@
   ansible.builtin.shell: |
     set -o pipefail
     buildah rm buildah-nexus || true
+  args:
+    executable: /bin/bash
   register: nexus_remove_image
   changed_when: "nexus_remove_image.rc == 0"
 

--- a/kubeinit/roles/kubeinit_nfs/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_nfs/tasks/main.yml
@@ -31,11 +31,11 @@
     echo '/var/nfsshare {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }}(rw,sync,no_root_squash,no_all_squash,no_wdelay)' | tee /etc/exports
     setsebool -P nfs_export_all_rw 1
     systemctl restart nfs-server
+  args:
+    executable: /bin/bash
   register: nfs_share_config
   changed_when: "nfs_share_config.rc == 0"
   when: kubeinit_inventory_cluster_distro == 'okd' or kubeinit_inventory_cluster_distro == 'k8s' or kubeinit_inventory_cluster_distro == 'eks'
-  args:
-    executable: /bin/bash
 
 - name: "configure NFS shares of Ubuntu based guests"
   ansible.builtin.shell: |
@@ -46,11 +46,11 @@
     echo '/var/nfsshare {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }}(rw,sync,no_root_squash,no_all_squash,no_wdelay)' | tee /etc/exports
     exportfs -a
     systemctl restart nfs-kernel-server
+  args:
+    executable: /bin/bash
   register: nfs_share_config
   changed_when: "nfs_share_config.rc == 0"
   when: kubeinit_inventory_cluster_distro == 'rke' or kubeinit_inventory_cluster_distro == 'cdk'
-  args:
-    executable: /bin/bash
 
 #
 # add nfs dynamic provisioning

--- a/kubeinit/roles/kubeinit_okd/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/10_configure_service_nodes.yml
@@ -298,6 +298,8 @@
         key="mastersSchedulable"
         new_value="true"
         sed -r "s/^(\s*${key}\s*:\s*).*/\1${new_value}/" -i "$yaml_file"
+      args:
+        executable: /bin/bash
       register: enable_masters_sched
       changed_when: "enable_masters_sched.rc == 0"
       when: groups['all_worker_nodes'] | list | length == 0
@@ -310,6 +312,8 @@
         key="mastersSchedulable"
         new_value="false"
         sed -r "s/^(\s*${key}\s*:\s*).*/\1${new_value}/" -i "$yaml_file"
+      args:
+        executable: /bin/bash
       register: disable_masters_sched
       changed_when: "disable_masters_sched.rc == 0"
       when: groups['all_worker_nodes'] | list | length > 0

--- a/kubeinit/roles/kubeinit_okd/tasks/50_post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/50_post_deployment_tasks.yml
@@ -93,6 +93,8 @@
         echo "show stat" | socat unix-connect:/var/lib/haproxy/stats stdio
         export KUBECONFIG=~/install_dir/auth/kubeconfig
         oc get nodes
+      args:
+        executable: /bin/bash
       ignore_errors: yes
       register: final_output_info
       changed_when: "final_output_info.rc == 0"

--- a/kubeinit/roles/kubeinit_prepare/tasks/10_cleanup.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/10_cleanup.yml
@@ -37,6 +37,8 @@
         ovn-nbctl lr-del lr0 || true
         ovn-nbctl ls-del public || true
         ip route del {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} via 172.16.0.1 dev br-ex || true
+      args:
+        executable: /bin/bash
       register: libvirt_clean_ovn
       changed_when: "libvirt_clean_ovn.rc == 0"
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_localhost.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_localhost.yml
@@ -32,6 +32,8 @@
     ssh-keygen -R  {{ item }}.{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }} || true
     ssh-keygen -R  {{ hostvars[item].ansible_host }} || true
   with_items: "{{ groups['all_nodes'] }}"
+  args:
+    executable: /bin/bash
   register: prepare_reset_keys
   changed_when: "prepare_reset_keys.rc == 0"
 

--- a/kubeinit/roles/kubeinit_registry/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/main.yml
@@ -46,10 +46,10 @@
   ansible.builtin.shell: |
     set -o pipefail
     python3 -m pip install passlib
-  register: install_passlib
-  changed_when: "install_passlib.rc == 0"
   args:
     executable: /bin/bash
+  register: install_passlib
+  changed_when: "install_passlib.rc == 0"
 
 - name: Create directory to hold the registry files
   ansible.builtin.file:

--- a/kubeinit/roles/kubeinit_validations/tasks/10_libvirt_free_space.yml
+++ b/kubeinit/roles/kubeinit_validations/tasks/10_libvirt_free_space.yml
@@ -28,6 +28,8 @@
     else
         df -BG --output=avail {{ kubeinit_validations_libvirt_path_fallback }} | grep -v Avail
     fi
+  args:
+    executable: /bin/bash
   register: kubeinit_validations_libvirt_free_space
   with_items:
     - "{{ groups['all_hosts'] | list }}"

--- a/kubeinit/roles/kubeinit_validations/tasks/20_libvirt_available_ram.yml
+++ b/kubeinit/roles/kubeinit_validations/tasks/20_libvirt_available_ram.yml
@@ -23,6 +23,8 @@
   ansible.builtin.shell: |
     set -o pipefail
     free --kilo  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 2
+  args:
+    executable: /bin/bash
   register: kubeinit_validations_libvirt_total_ram
   with_items:
     - "{{ groups['all_hosts'] | list }}"

--- a/kubeinit/roles/kubeinit_validations/tasks/30_libvirt_check_cpu_cores.yml
+++ b/kubeinit/roles/kubeinit_validations/tasks/30_libvirt_check_cpu_cores.yml
@@ -23,6 +23,8 @@
   ansible.builtin.shell: |
     set -o pipefail
     cat /proc/cpuinfo | grep processor | grep : | wc -l
+  args:
+    executable: /bin/bash
   register: kubeinit_validations_libvirt_total_cores
   with_items:
     - "{{ groups['all_hosts'] | list }}"


### PR DESCRIPTION
Using set -o pipefail only works when the executable is /bin/bash.