### PR TITLE
fix: adjust workflows to point to main

### DIFF
--- a/.github/workflows/docs_build_pr.yml
+++ b/.github/workflows/docs_build_pr.yml
@@ -3,7 +3,7 @@ name: docs_build_pr
 on:
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: release
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release_sw:
     if: github.repository_owner == 'Kubeinit'
@@ -172,7 +172,7 @@ jobs:
           git add .
           git commit -m "Update documentation" -a || true
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: kubeinit/github-push-action@master
         with:
           force: true
           branch: gh-pages


### PR DESCRIPTION
This commit fixes the job default branch
for the GH actions pointing to master.