### PR TITLE
fix: rework changes so that ovn network installs consistently

### DIFF
--- a/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
@@ -68,69 +68,6 @@ kubeinit_libvirt_source_images:
     raw: "rhcos-metal.x86_64.raw.gz"
     sig: ""
     rootfs: rhcos-live-rootfs.x86_64.img
-kubeinit_libvirt_hypervisor_dependencies:
-  centos:
-    - libguestfs-tools-c
-    - python3-libselinux
-    - libvirt
-    - libvirt-daemon
-    - libvirt-daemon-kvm
-    - libvirt-client
-    - qemu-kvm
-    - virt-install
-    - virt-top
-    - virt-viewer
-    - libguestfs-tools
-    - lvm2
-    - python3-libvirt
-    - python3-lxml
-    - python3-netaddr
-    - curl
-    - binutils
-    - qt5-qtbase
-    - gcc
-    - make
-    - patch
-    - libgomp
-    - glibc-headers
-    - glibc-devel
-    - kernel-headers
-    - kernel-devel
-    - bash-completion
-    - nano
-    - wget
-    - python3-pip
-    - iptables-services
-    - net-tools
-    - xz
-    - firewalld
-    - perl-XML-XPath
-  debian:
-    - sudo
-    - numad
-    - qemu
-    - qemu-kvm
-    - qemu-system
-    - libvirt-clients
-    - libvirt-daemon-system
-    - libvirt-daemon
-    - virt-manager
-    - virt-top
-    - bridge-utils
-    - libguestfs-tools
-    - genisoimage
-    - virtinst
-    - libosinfo-bin
-    - python3
-    - python3-pip
-    - python3-libvirt
-    - python3-lxml
-    - python3-netaddr
-    - nano
-    - wget
-    - xz-utils
-    - inetutils-ping
-    - libxml-xpath-perl
 
 kubeinit_libvirt_hypervisor_tmp_dir: /tmp
 kubeinit_libvirt_destroy_nets: True

--- a/kubeinit/roles/kubeinit_libvirt/tasks/10_cleanup.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/10_cleanup.yml
@@ -57,25 +57,19 @@
       with_items: "{{ groups['all_nodes'] }}"
       when: item in running_vms.list_vms
 
-    - name: Get all the destroyed VMs
-      community.libvirt.virt:
-        command: list_vms
-        state: destroyed
-      register: destroyed_vms
-
     - name: Undefine vms
       community.libvirt.virt:
         name: "{{ item }}"
         command: undefine
       with_items: "{{ groups['all_nodes'] }}"
-      when: item in destroyed_vms.list_vms
+      when: item in running_vms.list_vms
 
     - name: Remove VMs storage
       ansible.builtin.file:
         state: absent
         path: "{{ kubeinit_libvirt_target_image_dir }}/{{ item }}.qcow2"
       with_items: "{{ groups['all_nodes'] }}"
-      when: item in destroyed_vms.list_vms
+      when: item in running_vms.list_vms
 
     ##
     ## Clean folders

--- a/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_centos_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_centos_guest.yml
@@ -79,7 +79,7 @@
             {% for net in kubeinit_libvirt_cluster_nets %}
               {% if net.enabled %}
                 {% if kubeinit_libvirt_ovn_enabled %}
-                  --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_deployment_node_name.split("-")[1][:2] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
+                  --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_deployment_node_name.split("-")[1][:3] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
                 {% else %}
                   --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }}{% endif %},model=virtio \
                 {% endif %}

--- a/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_coreos_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_coreos_guest.yml
@@ -87,7 +87,7 @@
             {% for net in kubeinit_libvirt_cluster_nets %}
               {% if net.enabled %}
                 {% if kubeinit_libvirt_ovn_enabled %}
-                  --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_deployment_node_name.split("-")[1][:2] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
+                  --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_deployment_node_name.split("-")[1][:3] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
                 {% else %}
                   --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }}{% endif %},model=virtio \
                 {% endif %}

--- a/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_ubuntu_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_ubuntu_guest.yml
@@ -86,7 +86,7 @@
             {% for net in kubeinit_libvirt_cluster_nets %}
               {% if net.enabled %}
                 {% if kubeinit_libvirt_ovn_enabled %}
-                  --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_deployment_node_name.split("-")[1][:2] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
+                  --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_deployment_node_name.split("-")[1][:3] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
                 {% else %}
                   --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }}{% endif %},model=virtio \
                 {% endif %}

--- a/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
@@ -115,52 +115,11 @@
         state: disabled
       when: (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
 
-    - name: Install CentOS based requirements
-      ansible.builtin.package:
-        name: "{{ kubeinit_libvirt_hypervisor_dependencies.centos }}"
-        state: present
-      when: (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
-      register: installed_packages_centos
-
-    - name: Disable Services (firewalld)
-      ansible.builtin.service:
-        name: "firewalld"
-        state: stopped
-        enabled: no
-      when: (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
-
-    - name: Install Debian based requirements
-      ansible.builtin.package:
-        name: "{{ kubeinit_libvirt_hypervisor_dependencies.debian }}"
-        state: present
-      when: (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Debian' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Ubuntu')
-      register: installed_packages_debian
-
-    - name: Upgrade all packages
-      ansible.builtin.package:
-        name: '*'
-        state: latest
-      register: upgraded_packages
-
     - name: Enable and start libvirtd
       ansible.builtin.service:
         name: libvirtd
         enabled: yes
         state: started
-
-    - name: Restart if required
-      ansible.builtin.set_fact:
-        kubeinit_libvirt_restart: (installed_packages_debian.changed or installed_packages_centos.changed or upgraded_packages.changed)
-
-    - name: Reboot host and wait for it to restart
-      ansible.builtin.reboot:
-        msg: "Reboot initiated by a package upgrade"
-        connect_timeout: 5
-        reboot_timeout: 600
-        pre_reboot_delay: 0
-        post_reboot_delay: 30
-        test_command: whoami
-      when: kubeinit_libvirt_restart | bool
 
     - name: Set qemu user depending on the operative system
       ansible.builtin.set_fact:

--- a/kubeinit/roles/kubeinit_prepare/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_prepare/defaults/main.yml
@@ -25,3 +25,67 @@ kubeinit_libvirt_ovn_encapsulation: geneve
 kubeinit_libvirt_ovn_switch: sw0
 kubeinit_libvirt_ovn_northbound_port: 6641
 kubeinit_libvirt_ovn_southbound_port: 6642
+
+kubeinit_libvirt_hypervisor_dependencies:
+  centos:
+    - libguestfs-tools-c
+    - python3-libselinux
+    - libvirt
+    - libvirt-daemon
+    - libvirt-daemon-kvm
+    - libvirt-client
+    - qemu-kvm
+    - virt-install
+    - virt-top
+    - virt-viewer
+    - libguestfs-tools
+    - lvm2
+    - python3-libvirt
+    - python3-lxml
+    - python3-netaddr
+    - curl
+    - binutils
+    - qt5-qtbase
+    - gcc
+    - make
+    - patch
+    - libgomp
+    - glibc-headers
+    - glibc-devel
+    - kernel-headers
+    - kernel-devel
+    - bash-completion
+    - nano
+    - wget
+    - python3-pip
+    - iptables-services
+    - net-tools
+    - xz
+    - firewalld
+    - perl-XML-XPath
+  debian:
+    - sudo
+    - numad
+    - qemu
+    - qemu-kvm
+    - qemu-system
+    - libvirt-clients
+    - libvirt-daemon-system
+    - libvirt-daemon
+    - virt-manager
+    - virt-top
+    - bridge-utils
+    - libguestfs-tools
+    - genisoimage
+    - virtinst
+    - libosinfo-bin
+    - python3
+    - python3-pip
+    - python3-libvirt
+    - python3-lxml
+    - python3-netaddr
+    - nano
+    - wget
+    - xz-utils
+    - inetutils-ping
+    - libxml-xpath-perl

--- a/kubeinit/roles/kubeinit_prepare/tasks/10_cleanup.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/10_cleanup.yml
@@ -15,30 +15,18 @@
 # under the License.
 
 ##
-## Cleanup tasks
+## Clean OVN resources
 ##
-- name: Cleanup the networks
-  block:
-    ##
-    ## Clean OVN resources
-    ##
-    - name: Clean OVN/OVS resources
-      ansible.builtin.shell: |
-        set -o pipefail
-        ###############################################
-        # WARNING: We can not remove the external     #
-        # bridge interface kiextbr0, the connection   #
-        # will be lost if this is executed in the HVs #
-        ###############################################
-        ovs-vsctl del-br br-int || true
-        ovs-vsctl del-br br-ex || true
-        ovn-nbctl ls-del sw0 || true
-        ovn-nbctl ls-del sw1 || true
-        ovn-nbctl lr-del lr0 || true
-        ovn-nbctl ls-del public || true
-        ip route del {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} via 172.16.0.1 dev br-ex || true
-      args:
-        executable: /bin/bash
-      register: libvirt_clean_ovn
-      changed_when: "libvirt_clean_ovn.rc == 0"
-  delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
+- name: Clean OVN/OVS resources
+  ansible.builtin.shell: |
+    set -o pipefail
+    ovs-vsctl del-br br-int || true
+    ovs-vsctl del-br br-ex || true
+    ovn-nbctl ls-del sw0 || true
+    ovn-nbctl lr-del lr0 || true
+    ovn-nbctl ls-del public || true
+    ip route del {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} via 172.16.0.1 dev br-ex || true
+  args:
+    executable: /bin/bash
+  register: libvirt_clean_ovn
+  changed_when: "libvirt_clean_ovn.rc == 0"

--- a/kubeinit/roles/kubeinit_prepare/tasks/20_ovn_install.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/20_ovn_install.yml
@@ -17,120 +17,116 @@
 ##
 ## OVN packages setup in the Hypervisors.
 ##
-- name: Set up Hypervisors with OVN (package install)
-  block:
 
-    #
-    # We install all OVN requirements in the first hypervisor
-    #
-    - name: Install OVN packages in CentOS/RHEL (Master Hypervisor)
-      ansible.builtin.shell: |
-        # http://mirror.centos.org/centos/8/nfv/x86_64/openvswitch-2/Packages/o/
-        dnf install -y centos-release-nfv-openvswitch
-        yum install -y openvswitch2.13 ovn2.13 ovn2.13-central ovn2.13-host
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name and
-        (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat')
-      changed_when: false
+#
+# We install all OVN requirements in the first hypervisor
+#
+- name: Install OVN packages in CentOS/RHEL (Master Hypervisor)
+  ansible.builtin.shell: |
+    # http://mirror.centos.org/centos/8/nfv/x86_64/openvswitch-2/Packages/o/
+    dnf install -y centos-release-nfv-openvswitch
+    dnf install -y openvswitch2.13 ovn2.13 ovn2.13-central ovn2.13-host
+  when: >
+    kubeinit_bastion_host in kubeinit_deployment_node_name and
+    (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat')
+  changed_when: false
 
-    - name: Install OVN packages in Fedora (Master Hypervisor)
-      ansible.builtin.shell: |
-        yum install -y openvswitch ovn ovn-central ovn-host
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name and
-        (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
-      changed_when: false
+- name: Install OVN packages in Fedora (Master Hypervisor)
+  ansible.builtin.shell: |
+    yum install -y openvswitch ovn ovn-central ovn-host
+  when: >
+    kubeinit_bastion_host in kubeinit_deployment_node_name and
+    (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
+  changed_when: false
 
-    - name: Install OVN packages in Ubuntu/Debian (Master Hypervisor)
-      ansible.builtin.shell: |
-        apt-get install -y openvswitch-common \
-                           openvswitch-switch \
-                           ovn-common \
-                           ovn-host \
-                           ovn-central
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name and
-        (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Debian' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Ubuntu')
-      changed_when: false
+- name: Install OVN packages in Ubuntu/Debian (Master Hypervisor)
+  ansible.builtin.shell: |
+    apt-get install -y openvswitch-common \
+                       openvswitch-switch \
+                       ovn-common \
+                       ovn-host \
+                       ovn-central
+  when: >
+    kubeinit_bastion_host in kubeinit_deployment_node_name and
+    (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Debian' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Ubuntu')
+  changed_when: false
 
-    #
-    # We DO NOT install ovn-central (OVN requirement) in the other hypervisors
-    #
-    - name: Install OVN packages in CentOS/RHEL (Slave Hypervisor)
-      ansible.builtin.shell: |
-        # http://mirror.centos.org/centos/8/nfv/x86_64/openvswitch-2/Packages/o/
-        dnf install -y centos-release-nfv-openvswitch
-        yum install -y openvswitch2.13 ovn2.13 ovn2.13-host
-      when: >
-        (kubeinit_bastion_host not in kubeinit_deployment_node_name) and
-        (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat')
-      changed_when: false
+#
+# We DO NOT install ovn-central (OVN requirement) in the other hypervisors
+#
+- name: Install OVN packages in CentOS/RHEL (Slave Hypervisor)
+  ansible.builtin.shell: |
+    # http://mirror.centos.org/centos/8/nfv/x86_64/openvswitch-2/Packages/o/
+    dnf install -y centos-release-nfv-openvswitch
+    yum install -y openvswitch2.13 ovn2.13 ovn2.13-host
+  when: >
+    (kubeinit_bastion_host not in kubeinit_deployment_node_name) and
+    (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat')
+  changed_when: false
 
-    - name: Install OVN packages in Fedora (Slave Hypervisor)
-      ansible.builtin.shell: |
-        yum install -y openvswitch ovn ovn-host
-      when: >
-        (kubeinit_bastion_host not in kubeinit_deployment_node_name) and
-        (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
-      changed_when: false
+- name: Install OVN packages in Fedora (Slave Hypervisor)
+  ansible.builtin.shell: |
+    yum install -y openvswitch ovn ovn-host
+  when: >
+    (kubeinit_bastion_host not in kubeinit_deployment_node_name) and
+    (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
+  changed_when: false
 
-    - name: Install OVN packages in Ubuntu/Debian (Slave Hypervisor)
-      ansible.builtin.shell: |
-        apt-get install -y openvswitch-common \
-                           openvswitch-switch \
-                           ovn-common \
-                           ovn-host
-      when: >
-        (kubeinit_bastion_host not in kubeinit_deployment_node_name) and
-        (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Debian' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Ubuntu')
-      changed_when: false
+- name: Install OVN packages in Ubuntu/Debian (Slave Hypervisor)
+  ansible.builtin.shell: |
+    apt-get install -y openvswitch-common \
+                       openvswitch-switch \
+                       ovn-common \
+                       ovn-host
+  when: >
+    (kubeinit_bastion_host not in kubeinit_deployment_node_name) and
+    (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Debian' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Ubuntu')
+  changed_when: false
 
-    # - name: Refresh firewalld services list
-    #   ansible.builtin.shell: |
-    #     firewall-cmd --reload
-    #   when: >
-    #     (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
-    #
-    # - name: Enable OVN central in firewalld
-    #   ansible.posix.firewalld:
-    #     service: ovn-central-firewall-service
-    #     permanent: yes
-    #     state: enabled
-    #     immediate: yes
-    #   when: >
-    #     kubeinit_bastion_host in kubeinit_deployment_node_name and
-    #     (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
-    #
-    # - name: Enable OVN controller in firewalld
-    #   ansible.posix.firewalld:
-    #     service: ovn-host-firewall-service
-    #     permanent: yes
-    #     state: enabled
-    #     immediate: yes
-    #   when: >
-    #     (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
+# - name: Refresh firewalld services list
+#   ansible.builtin.shell: |
+#     firewall-cmd --reload
+#   when: >
+#     (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
+#
+# - name: Enable OVN central in firewalld
+#   ansible.posix.firewalld:
+#     service: ovn-central-firewall-service
+#     permanent: yes
+#     state: enabled
+#     immediate: yes
+#   when: >
+#     kubeinit_bastion_host in kubeinit_deployment_node_name and
+#     (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
+#
+# - name: Enable OVN controller in firewalld
+#   ansible.posix.firewalld:
+#     service: ovn-host-firewall-service
+#     permanent: yes
+#     state: enabled
+#     immediate: yes
+#   when: >
+#     (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
 
-    - name: Enable and start OVN services in the first hypervisor
-      ansible.builtin.service:
-        name: "{{ item }}"
-        state: started
-        enabled: yes
-      with_items:
-        - openvswitch
-        - ovn-northd
-        - ovn-controller
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name
+- name: Enable and start OVN services in the first hypervisor
+  ansible.builtin.service:
+    name: "{{ item }}"
+    state: started
+    enabled: yes
+  with_items:
+    - openvswitch
+    - ovn-northd
+    - ovn-controller
+  when: >
+    kubeinit_bastion_host in kubeinit_deployment_node_name
 
-    - name: Enable and start OVN services in the rest of the hypervisors
-      ansible.builtin.service:
-        name: "{{ item }}"
-        state: started
-        enabled: yes
-      with_items:
-        - openvswitch
-        - ovn-controller
-      when: >
-        (kubeinit_bastion_host not in kubeinit_deployment_node_name)
-
-  delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
+- name: Enable and start OVN services in the rest of the hypervisors
+  ansible.builtin.service:
+    name: "{{ item }}"
+    state: started
+    enabled: yes
+  with_items:
+    - openvswitch
+    - ovn-controller
+  when: >
+    (kubeinit_bastion_host not in kubeinit_deployment_node_name)

--- a/kubeinit/roles/kubeinit_prepare/tasks/40_ovn_setup.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/40_ovn_setup.yml
@@ -34,3 +34,5 @@
     # we will use br-int so no need to removing it before
     ovs-vsctl --may-exist add-br br-int
     # This is executed in every Hypervisor
+  register: ovs_setup
+  changed_when: "ovs_setup.rc == 0"

--- a/kubeinit/roles/kubeinit_prepare/tasks/40_ovn_setup.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/40_ovn_setup.yml
@@ -18,23 +18,19 @@
 ## OVN hypervisors setup.
 ##
 
-- name: Set up the OVN network details
-  block:
-
-    - name: Configure OVS on the Hypervisors
-      ansible.builtin.shell: |
-        CENTRAL_IP={{ kubeinit_bastion_host_address }} # This is the IP of the first HV
-        LOCAL_IP={{ hostvars[kubeinit_deployment_node_name]['ansible_default_ipv4']['address'] }} # This is the IP of the current HV
-        ENCAP_TYPE={{ kubeinit_libvirt_ovn_encapsulation }}
-        ovs-vsctl set Open_vSwitch . \
-            external_ids:ovn-remote="tcp:$CENTRAL_IP:{{ kubeinit_libvirt_ovn_southbound_port }}" \
-            external_ids:ovn-nb="tcp:$CENTRAL_IP:{{ kubeinit_libvirt_ovn_northbound_port }}" \
-            external_ids:ovn-encap-ip=$LOCAL_IP \
-            external_ids:ovn-encap-type="$ENCAP_TYPE" \
-            external_ids:system-id="{{ kubeinit_deployment_node_name }}"
-        # On each HV lets create a virtual bridge br-int
-        # This bridge will be used when we create the VMs
-        # we will use br-int so no need to removing it before
-        ovs-vsctl --may-exist add-br br-int
-        # This is executed in every Hypervisor
-  delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
+- name: Configure OVS on the Hypervisors
+  ansible.builtin.shell: |
+    CENTRAL_IP={{ kubeinit_bastion_host_address }} # This is the IP of the first HV
+    LOCAL_IP={{ hostvars[kubeinit_deployment_node_name]['ansible_default_ipv4']['address'] }} # This is the IP of the current HV
+    ENCAP_TYPE={{ kubeinit_libvirt_ovn_encapsulation }}
+    ovs-vsctl set Open_vSwitch . \
+        external_ids:ovn-remote="tcp:$CENTRAL_IP:{{ kubeinit_libvirt_ovn_southbound_port }}" \
+        external_ids:ovn-nb="tcp:$CENTRAL_IP:{{ kubeinit_libvirt_ovn_northbound_port }}" \
+        external_ids:ovn-encap-ip=$LOCAL_IP \
+        external_ids:ovn-encap-type="$ENCAP_TYPE" \
+        external_ids:system-id="{{ kubeinit_deployment_node_name }}"
+    # On each HV lets create a virtual bridge br-int
+    # This bridge will be used when we create the VMs
+    # we will use br-int so no need to removing it before
+    ovs-vsctl --may-exist add-br br-int
+    # This is executed in every Hypervisor

--- a/kubeinit/roles/kubeinit_prepare/tasks/50_ovn_post_setup.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/50_ovn_post_setup.yml
@@ -18,171 +18,151 @@
 ## OVN post deployment configuration steps.
 ##
 
-- name: Post set up the OVN network details
-  block:
+- name: Configure OVN in the first Hypervisor
+  ansible.builtin.shell: |
+    # Below two commands only for master. For SSL, other steps are required.
+    ovn-nbctl set-connection ptcp:{{ kubeinit_libvirt_ovn_northbound_port }}
+    ovn-sbctl set-connection ptcp:{{ kubeinit_libvirt_ovn_southbound_port }}
 
-    - name: Configure OVN in the first Hypervisor
-      ansible.builtin.shell: |
-        # Below two commands only for master. For SSL, other steps are required.
-        ovn-nbctl set-connection ptcp:{{ kubeinit_libvirt_ovn_northbound_port }}
-        ovn-sbctl set-connection ptcp:{{ kubeinit_libvirt_ovn_southbound_port }}
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name
+#
+# We create the OVN switch that will be binded to each chassis (hypervisor)
+# In this switch we will create a port per guest
+#
+- name: Remove and create the cluster switch if exists
+  ansible.builtin.shell: |
+    #
+    # Create a logical switch
+    #
+    ovn-nbctl ls-del sw0
+    ovn-nbctl --wait=hv ls-add sw0
+
+- name: Create the DHCP options
+  ansible.builtin.shell: |
+    #
+    # Create DHCP options
+    #
+    Dhcp_opts=$(ovn-nbctl create DHCP_Options cidr={{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} \
+        options=" \
+                \"server_id\"=\"{{ kubeinit_inventory_network_gateway }}\" \
+                \"server_mac\"=\"00:00:00:65:77:09\" \
+                \"lease_time\"=\"3600\" \
+                \"router\"=\"{{ kubeinit_inventory_network_gateway }}\" \
+                \"dns_server\"=\"{{ kubeinit_inventory_cluster_dns_server }}\" \
+                \"mtu\"=\"1442\" \
+                ")
+    echo $Dhcp_opts
+  register: dhcp_options
+  changed_when: "dhcp_options.rc == 0"
+
+- name: Register the dhcp options uuid
+  ansible.builtin.set_fact: kubeinit_provision_dhcp_options={{ dhcp_options.stdout }}
+  with_items:
+    - "{{ groups['all_hosts'] }}"
+  delegate_to: "{{ item }}"
+
+- name: Display the registered dhcp options
+  ansible.builtin.debug:
+    var: kubeinit_provision_dhcp_options
+
+- name: Create OVS/OVN bindings for the VMs ports
+  ansible.builtin.shell: |
+    #
+    # We create an OVN port using the interface ID and the mac address of the VM
+    #
+    ovn-nbctl --wait=hv lsp-add sw0 {{ hostvars[item].interfaceid }}
 
     #
-    # We create the OVN switch that will be binded to each chassis (hypervisor)
-    # In this switch we will create a port per guest
+    # The port name is the interface id of the VM, now we assign the mac address of the VM to the port
     #
-    - name: Remove and create the cluster switch if exists
-      ansible.builtin.shell: |
-        #
-        # Create a logical switch
-        #
-        ovn-nbctl ls-del sw0
-        ovn-nbctl --wait=hv ls-add sw0
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name
+    ovn-nbctl lsp-set-addresses {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
 
-    - name: Create the DHCP options
-      ansible.builtin.shell: |
-        #
-        # Create DHCP options
-        #
-        Dhcp_opts=$(ovn-nbctl create DHCP_Options cidr={{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} \
-            options=" \
-                    \"server_id\"=\"{{ kubeinit_inventory_network_gateway }}\" \
-                    \"server_mac\"=\"00:00:00:65:77:09\" \
-                    \"lease_time\"=\"3600\" \
-                    \"router\"=\"{{ kubeinit_inventory_network_gateway }}\" \
-                    \"dns_server\"=\"{{ kubeinit_inventory_cluster_dns_server }}\" \
-                    \"mtu\"=\"1442\" \
-                    ")
-        echo $Dhcp_opts
-      register: dhcp_options
-      changed_when: "dhcp_options.rc == 0"
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name
+    ovn-nbctl lsp-set-port-security {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
 
-    - name: Register the dhcp options uuid
-      ansible.builtin.set_fact: kubeinit_provision_dhcp_options={{ dhcp_options.stdout }}
-      with_items:
-        - "{{ groups['all_hosts'] }}"
-      delegate_to: "{{ item }}"
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name
+    ovn-nbctl lsp-set-dhcpv4-options {{ hostvars[item].interfaceid }} {{ kubeinit_provision_dhcp_options }}
 
-    - name: Display the registered dhcp options
-      ansible.builtin.debug:
-        var: kubeinit_provision_dhcp_options
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name
+  with_items: "{{ groups['all_nodes'] }}"
 
-    - name: Create OVS/OVN bindings for the VMs ports
-      ansible.builtin.shell: |
-        #
-        # We create an OVN port using the interface ID and the mac address of the VM
-        #
-        ovn-nbctl --wait=hv lsp-add sw0 {{ hostvars[item].interfaceid }}
+- name: Configuring a router connected to the guests switch
+  ansible.builtin.shell: |
+    #
+    # Create a logical router to connect the VMs switch
+    #
+    ovn-nbctl --wait=hv lr-add lr0
+    ovn-nbctl --wait=hv lrp-add lr0 lr0-sw0 00:00:00:65:77:09 {{ kubeinit_inventory_network_gateway }}/{{ kubeinit_inventory_network_cidr }}
+    ovn-nbctl --wait=hv lsp-add sw0 sw0-lr0
+    ovn-nbctl lsp-set-type sw0-lr0 router
+    ovn-nbctl lsp-set-addresses sw0-lr0 router
+    ovn-nbctl lsp-set-options sw0-lr0 router-port=lr0-sw0
+    #
+    # We create the external access switch
+    #
+    ovn-nbctl --wait=hv ls-add public
+    ovn-nbctl --wait=hv lrp-add lr0 lr0-public 00:00:20:20:12:13 172.16.0.1/24
+    ovn-nbctl --wait=hv lsp-add public public-lr0
+    ovn-nbctl lsp-set-type public-lr0 router
+    ovn-nbctl lsp-set-addresses public-lr0 router
+    ovn-nbctl lsp-set-options public-lr0 router-port=lr0-public
+    #
+    # Create a localnet port
+    #
+    ovn-nbctl --wait=hv lsp-add public public-ln
+    ovn-nbctl lsp-set-type public-ln localnet
+    ovn-nbctl lsp-set-addresses public-ln unknown
+    ovn-nbctl lsp-set-options public-ln network_name=provider
+    #
+    # We add a bridge mapping from br-ex called provider
+    #
+    ovs-vsctl set Open_vSwitch . external-ids:ovn-bridge-mappings=provider:br-ex
+    #
+    # Configuring the chassis gateway to the first hypervisor
+    #
+    ovn-nbctl lrp-set-gateway-chassis lr0-public {{ kubeinit_bastion_host }}
+    ovn-nbctl \
+      --id=@gc0 create Gateway_Chassis name=lr0-public chassis_name={{ kubeinit_bastion_host }} priority=20 -- \
+      set Logical_Router_Port lr0-public 'gateway_chassis=[@gc0]'
+    ovn-nbctl set logical_router_port lr0-public options:redirect-chassis={{ kubeinit_bastion_host }}
+    #
+    # Create an ovs br-ex bridge to connect to the host
+    #
+    ovs-vsctl --may-exist add-br br-ex
+    ip addr add 172.16.0.254/24 dev br-ex
+    ip link set br-ex up
 
-        #
-        # The port name is the interface id of the VM, now we assign the mac address of the VM to the port
-        #
-        ovn-nbctl lsp-set-addresses {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
+    #
+    # Routes
+    #
+    # Connectivity from the host to the guest machines
+    ip route add {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} via 172.16.0.1 dev br-ex
+    # Connectivity to external/additional networks
+    ovn-nbctl lr-route-add lr0 0.0.0.0/0 172.16.0.254
+    #
+    # Disable rp_filter
+    #
+    sysctl net.ipv4.conf.all.rp_filter=2
 
-        ovn-nbctl lsp-set-port-security {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
-
-        ovn-nbctl lsp-set-dhcpv4-options {{ hostvars[item].interfaceid }} {{ kubeinit_provision_dhcp_options }}
-
-      with_items: "{{ groups['all_nodes'] }}"
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name
-
-    - name: Configuring a router connected to the guests switch
-      ansible.builtin.shell: |
-        #
-        # Create a logical router to connect the VMs switch
-        #
-        ovn-nbctl --wait=hv lr-add lr0
-        ovn-nbctl --wait=hv lrp-add lr0 lr0-sw0 00:00:00:65:77:09 {{ kubeinit_inventory_network_gateway }}/{{ kubeinit_inventory_network_cidr }}
-        ovn-nbctl --wait=hv lsp-add sw0 sw0-lr0
-        ovn-nbctl lsp-set-type sw0-lr0 router
-        ovn-nbctl lsp-set-addresses sw0-lr0 router
-        ovn-nbctl lsp-set-options sw0-lr0 router-port=lr0-sw0
-        #
-        # We create the external access switch
-        #
-        ovn-nbctl --wait=hv ls-add public
-        ovn-nbctl --wait=hv lrp-add lr0 lr0-public 00:00:20:20:12:13 172.16.0.1/24
-        ovn-nbctl --wait=hv lsp-add public public-lr0
-        ovn-nbctl lsp-set-type public-lr0 router
-        ovn-nbctl lsp-set-addresses public-lr0 router
-        ovn-nbctl lsp-set-options public-lr0 router-port=lr0-public
-        #
-        # Create a localnet port
-        #
-        ovn-nbctl --wait=hv lsp-add public public-ln
-        ovn-nbctl lsp-set-type public-ln localnet
-        ovn-nbctl lsp-set-addresses public-ln unknown
-        ovn-nbctl lsp-set-options public-ln network_name=provider
-        #
-        # We add a bridge mapping from br-ex called provider
-        #
-        ovs-vsctl set Open_vSwitch . external-ids:ovn-bridge-mappings=provider:br-ex
-        #
-        # Configuring the chassis gateway to the first hypervisor
-        #
-        ovn-nbctl lrp-set-gateway-chassis lr0-public {{ kubeinit_bastion_host }}
-        ovn-nbctl \
-          --id=@gc0 create Gateway_Chassis name=lr0-public chassis_name={{ kubeinit_bastion_host }} priority=20 -- \
-          set Logical_Router_Port lr0-public 'gateway_chassis=[@gc0]'
-        ovn-nbctl set logical_router_port lr0-public options:redirect-chassis={{ kubeinit_bastion_host }}
-        #
-        # Create an ovs br-ex bridge to connect to the host
-        #
-        ovs-vsctl --may-exist add-br br-ex
-        ip addr add 172.16.0.254/24 dev br-ex
-        ip link set br-ex up
-
-        #
-        # Routes
-        #
-        # Connectivity from the host to the guest machines
-        ip route add {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} via 172.16.0.1 dev br-ex
-        # Connectivity to external/additional networks
-        ovn-nbctl lr-route-add lr0 0.0.0.0/0 172.16.0.254
-        #
-        # Disable rp_filter
-        #
-        sysctl net.ipv4.conf.all.rp_filter=2
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name
-
-    - name: Configuring NAT when not using the external bridge interface
-      ansible.builtin.shell: |
-        #
-        # NAT from the external interface
-        #
-        # Get the external interface name
-        iface=$(ip route get "8.8.8.8" | grep -Po '(?<=(dev )).*(?= src| proto)')
-        #
-        iptables -t nat -A POSTROUTING -s {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} -o $iface -j MASQUERADE
-        #
-        iptables -A FORWARD -i $iface -j ACCEPT
-        iptables -A FORWARD -i br-ex -j ACCEPT
-        iptables -A FORWARD -o $iface -j ACCEPT
-        iptables -A FORWARD -o br-ex -j ACCEPT
-        #
-        iptables -A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT
-        #
-        iptables -P FORWARD ACCEPT
-        iptables -P INPUT ACCEPT
-        iptables -P OUTPUT ACCEPT
-      when: >
-        kubeinit_bastion_host in kubeinit_deployment_node_name
+- name: Configuring NAT when not using the external bridge interface
+  ansible.builtin.shell: |
+    #
+    # NAT from the external interface
+    #
+    # Get the external interface name
+    iface=$(ip route get "8.8.8.8" | grep -Po '(?<=(dev )).*(?= src| proto)')
+    #
+    iptables -t nat -A POSTROUTING -s {{ kubeinit_inventory_network_net }}/{{ kubeinit_inventory_network_cidr }} -o $iface -j MASQUERADE
+    #
+    iptables -A FORWARD -i $iface -j ACCEPT
+    iptables -A FORWARD -i br-ex -j ACCEPT
+    iptables -A FORWARD -o $iface -j ACCEPT
+    iptables -A FORWARD -o br-ex -j ACCEPT
+    #
+    iptables -A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT
+    #
+    iptables -P FORWARD ACCEPT
+    iptables -P INPUT ACCEPT
+    iptables -P OUTPUT ACCEPT
 
 # When the deployment finishes, it shuold be possible to see the available chassis and ports by running:
 # ovn-nbctl show
 # ovn-sbctl show
 # ovs-vsctl show
 # ovs-vsctl list interface veth0-ma01
-  delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"

--- a/kubeinit/roles/kubeinit_prepare/tasks/50_ovn_post_setup.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/50_ovn_post_setup.yml
@@ -23,6 +23,8 @@
     # Below two commands only for master. For SSL, other steps are required.
     ovn-nbctl set-connection ptcp:{{ kubeinit_libvirt_ovn_northbound_port }}
     ovn-sbctl set-connection ptcp:{{ kubeinit_libvirt_ovn_southbound_port }}
+  register: config_ovn_connection
+  changed_when: "config_ovn_connection.rc == 0"
 
 #
 # We create the OVN switch that will be binded to each chassis (hypervisor)
@@ -35,6 +37,8 @@
     #
     ovn-nbctl ls-del sw0
     ovn-nbctl --wait=hv ls-add sw0
+  register: config_ovn_switch
+  changed_when: "config_ovn_switch.rc == 0"
 
 - name: Create the DHCP options
   ansible.builtin.shell: |
@@ -70,17 +74,15 @@
     # We create an OVN port using the interface ID and the mac address of the VM
     #
     ovn-nbctl --wait=hv lsp-add sw0 {{ hostvars[item].interfaceid }}
-
     #
     # The port name is the interface id of the VM, now we assign the mac address of the VM to the port
     #
     ovn-nbctl lsp-set-addresses {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
-
     ovn-nbctl lsp-set-port-security {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
-
     ovn-nbctl lsp-set-dhcpv4-options {{ hostvars[item].interfaceid }} {{ kubeinit_provision_dhcp_options }}
-
   with_items: "{{ groups['all_nodes'] }}"
+  register: config_ovn_bindings
+  changed_when: "config_ovn_bindings.rc == 0"
 
 - name: Configuring a router connected to the guests switch
   ansible.builtin.shell: |
@@ -127,7 +129,6 @@
     ovs-vsctl --may-exist add-br br-ex
     ip addr add 172.16.0.254/24 dev br-ex
     ip link set br-ex up
-
     #
     # Routes
     #
@@ -139,9 +140,12 @@
     # Disable rp_filter
     #
     sysctl net.ipv4.conf.all.rp_filter=2
+  register: config_ovn_routing
+  changed_when: "config_ovn_routing.rc == 0"
 
 - name: Configuring NAT when not using the external bridge interface
   ansible.builtin.shell: |
+    set -eo pipefail
     #
     # NAT from the external interface
     #
@@ -160,6 +164,8 @@
     iptables -P FORWARD ACCEPT
     iptables -P INPUT ACCEPT
     iptables -P OUTPUT ACCEPT
+  register: config_iptables
+  changed_when: "config_iptables.rc == 0"
 
 # When the deployment finishes, it shuold be possible to see the available chassis and ports by running:
 # ovn-nbctl show

--- a/kubeinit/roles/kubeinit_prepare/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/main.yml
@@ -93,60 +93,11 @@
     tasks_from: prepare_localhost.yml
     public: true
 
-- name: Update the /etc/hosts file on each hypervisor with ansible aliases
-  ansible.builtin.lineinfile:
-    path: "/etc/hosts"
-    regexp: ".*    {{ hostvars[host]['inventory_hostname'] }}    {{ hostvars[host]['ansible_hostname'] }}    {{ hostvars[host]['ansible_host'] }}"
-    line: "{{ hostvars[host]['ansible_default_ipv4']['address'] }}    {{ hostvars[host]['inventory_hostname'] }}    {{ hostvars[host]['ansible_hostname'] }}    {{ hostvars[host]['ansible_host'] }}"
-    state: present
-    backup: yes
-  register: etchostsupdate
-  with_items:
-    - "{{ groups['all_hosts'] }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    host: "{{ kubeinit_deployment_node_name }}"
-  delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
-
-##
-## Configure OVN o a linux bridge in all the HVs
-##
-
-- name: Clean the netwokrs
-  ansible.builtin.include_tasks: 10_cleanup.yml
-  when: kubeinit_libvirt_ovn_enabled
-  with_items:
-    - "{{ groups['all_hosts'] }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-
-- name: Include the OVN install tasks
-  ansible.builtin.include_tasks: 20_ovn_install.yml
-  when: kubeinit_libvirt_ovn_enabled
-  with_items:
-    - "{{ groups['all_hosts'] }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-
-- name: Include the OVN setup
-  ansible.builtin.include_tasks: 40_ovn_setup.yml
-  when: kubeinit_libvirt_ovn_enabled
-  with_items:
-    - "{{ groups['all_hosts'] }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-
-- name: Post configure steps for OVN
-  ansible.builtin.include_tasks: 50_ovn_post_setup.yml
-  when: kubeinit_libvirt_ovn_enabled and (kubeinit_bastion_host in kubeinit_deployment_node_name)
+- name: Prepare hypervisors
+  ansible.builtin.include_role:
+    name: "../../roles/kubeinit_prepare"
+    tasks_from: prepare_hypervisor.yml
+    public: true
   with_items:
     - "{{ groups['all_hosts'] }}"
   loop_control:

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_hypervisor.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_hypervisor.yml
@@ -1,0 +1,105 @@
+---
+# Copyright 2020 KubeInit.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+#
+# Gather hosts information
+#
+
+- name: Delegate to kubeinit_deployment_node_name
+  block:
+
+    - name: Fix libvirt qemu bug
+      ansible.builtin.shell: |
+        set -eo pipefail
+        mkdir -p /etc/qemu/firmware
+        touch /etc/qemu/firmware/50-edk2-ovmf-cc.json
+      args:
+        executable: /bin/bash
+
+    - name: Update the /etc/hosts file on each hypervisor with ansible aliases
+      ansible.builtin.lineinfile:
+        path: "/etc/hosts"
+        regexp: ".*    {{ hostvars[host]['inventory_hostname'] }}    {{ hostvars[host]['ansible_hostname'] }}    {{ hostvars[host]['ansible_host'] }}"
+        line: "{{ hostvars[host]['ansible_default_ipv4']['address'] }}    {{ hostvars[host]['inventory_hostname'] }}    {{ hostvars[host]['ansible_hostname'] }}    {{ hostvars[host]['ansible_host'] }}"
+        state: present
+        backup: yes
+      register: etchostsupdate
+      vars:
+        host: "{{ kubeinit_deployment_node_name }}"
+
+    - name: Install CentOS based requirements
+      ansible.builtin.package:
+        name: "{{ kubeinit_libvirt_hypervisor_dependencies.centos }}"
+        state: present
+      when: (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
+      register: installed_packages_centos
+
+    - name: Disable Services (firewalld)
+      ansible.builtin.service:
+        name: "firewalld"
+        state: stopped
+        enabled: no
+      when: (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'CentOS' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'RedHat' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Fedora')
+
+    - name: Install Debian based requirements
+      ansible.builtin.package:
+        name: "{{ kubeinit_libvirt_hypervisor_dependencies.debian }}"
+        state: present
+      when: (hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Debian' or hostvars[kubeinit_deployment_node_name].ansible_distribution == 'Ubuntu')
+      register: installed_packages_debian
+
+    - name: Upgrade all packages
+      ansible.builtin.package:
+        name: '*'
+        state: latest
+      register: upgraded_packages
+
+    - name: Restart if required
+      ansible.builtin.set_fact:
+        kubeinit_libvirt_restart: (installed_packages_debian.changed or installed_packages_centos.changed or upgraded_packages.changed)
+
+    - name: Reboot host and wait for it to restart
+      ansible.builtin.reboot:
+        msg: "Reboot initiated by a package upgrade"
+        connect_timeout: 5
+        reboot_timeout: 600
+        pre_reboot_delay: 0
+        post_reboot_delay: 30
+        test_command: whoami
+      when: kubeinit_libvirt_restart | bool
+
+    ##
+    ## Configure OVN o a linux bridge in all the HVs
+    ##
+    
+    - name: Clean the netwokrs
+      ansible.builtin.include_tasks: 10_cleanup.yml
+      when: kubeinit_libvirt_ovn_enabled
+    
+    - name: Include the OVN install tasks
+      ansible.builtin.include_tasks: 20_ovn_install.yml
+      when: kubeinit_libvirt_ovn_enabled
+    
+    - name: Include the OVN setup
+      ansible.builtin.include_tasks: 40_ovn_setup.yml
+      when: kubeinit_libvirt_ovn_enabled
+    
+    - name: Post configure steps for OVN
+      ansible.builtin.include_tasks: 50_ovn_post_setup.yml
+      when: kubeinit_libvirt_ovn_enabled and (kubeinit_bastion_host in kubeinit_deployment_node_name)
+
+  delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_hypervisor.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_hypervisor.yml
@@ -85,19 +85,19 @@
     ##
     ## Configure OVN o a linux bridge in all the HVs
     ##
-    
+
     - name: Clean the netwokrs
       ansible.builtin.include_tasks: 10_cleanup.yml
       when: kubeinit_libvirt_ovn_enabled
-    
+
     - name: Include the OVN install tasks
       ansible.builtin.include_tasks: 20_ovn_install.yml
       when: kubeinit_libvirt_ovn_enabled
-    
+
     - name: Include the OVN setup
       ansible.builtin.include_tasks: 40_ovn_setup.yml
       when: kubeinit_libvirt_ovn_enabled
-    
+
     - name: Post configure steps for OVN
       ansible.builtin.include_tasks: 50_ovn_post_setup.yml
       when: kubeinit_libvirt_ovn_enabled and (kubeinit_bastion_host in kubeinit_deployment_node_name)

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_podman.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_podman.yml
@@ -20,10 +20,22 @@
     state: present
     name: "podman"
 
+- name: Read docker password from file
+  ansible.builtin.slurp:
+    src: "{{ kubeinit_common_docker_password }}"
+  register: docker_password
+  delegate_to: localhost
+  no_log: true
+  when: |
+    kubeinit_common_docker_username is defined and
+    kubeinit_common_docker_password is defined and
+    kubeinit_common_docker_username and
+    kubeinit_common_docker_password
+
 - name: Podman login to docker.io
   containers.podman.podman_login:
     username: "{{ kubeinit_common_docker_username }}"
-    password: "{{ kubeinit_common_docker_password }}"
+    password: "{{ docker_password.content | b64decode | trim }}"
     registry: "docker.io"
   no_log: true
   when: |
@@ -31,3 +43,8 @@
     kubeinit_common_docker_password is defined and
     kubeinit_common_docker_username and
     kubeinit_common_docker_password
+
+- name: clear any reference to docker password
+  ansible.builtin.set_fact:
+    docker_password: null
+  no_log: true

--- a/kubeinit/roles/kubeinit_prepare/templates/docker_io_pass.j2
+++ b/kubeinit/roles/kubeinit_prepare/templates/docker_io_pass.j2
@@ -1,1 +1,0 @@
-{{ kubeinit_common_docker_password }}


### PR DESCRIPTION
This commit addresses the following issues:
- Move all hypervisor preparation to prepare_hypervisor.yml
- Move installation of package dependencies from libvirt role
  to the prepare role.
- Undefine VMs and remove storage for all VMs that were found.
- Use first 3 characters from node names instead of 2 since both
  controller and compute start with co.
- Change docker password environment and ansible variable value
  from the actual password to the path of a file containing the
  password.