### PR TITLE
fix: cleanup prepare_podman tasks

### DIFF
--- a/kubeinit/roles/kubeinit_cdk/tasks/20_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/20_configure_service_nodes.yml
@@ -28,7 +28,7 @@
       containers.podman.podman_pod:
         name: "{{ kubeinit_services_pod_name }}"
         dns:
-          - "{{ kubeinit_services_service_address }}"
+          - "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
           - "{{ kubeinit_common_dns_master }}"
         dns_search: "{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }}"
         state: created

--- a/kubeinit/roles/kubeinit_eks/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/10_configure_service_nodes.yml
@@ -28,7 +28,7 @@
       containers.podman.podman_pod:
         name: "{{ kubeinit_services_pod_name }}"
         dns:
-          - "{{ kubeinit_services_service_address }}"
+          - "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
           - "{{ kubeinit_common_dns_master }}"
         dns_search: "{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }}"
         state: created

--- a/kubeinit/roles/kubeinit_k8s/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/10_configure_service_nodes.yml
@@ -27,7 +27,7 @@
       containers.podman.podman_pod:
         name: "{{ kubeinit_services_pod_name }}"
         dns:
-          - "{{ kubeinit_services_service_address }}"
+          - "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
           - "{{ kubeinit_common_dns_master }}"
         dns_search: "{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }}"
         state: created

--- a/kubeinit/roles/kubeinit_prepare/tasks/50_ovn_post_setup.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/50_ovn_post_setup.yml
@@ -80,7 +80,7 @@
     ovn-nbctl lsp-set-addresses {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
     ovn-nbctl lsp-set-port-security {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
     ovn-nbctl lsp-set-dhcpv4-options {{ hostvars[item].interfaceid }} {{ kubeinit_provision_dhcp_options }}
-  with_items: "{{ groups['all_nodes'] }}"
+  with_items: "{{ groups['all_virtual_nodes'] }}"
   register: config_ovn_bindings
   changed_when: "config_ovn_bindings.rc == 0"
 
@@ -171,4 +171,4 @@
 # ovn-nbctl show
 # ovn-sbctl show
 # ovs-vsctl show
-# ovs-vsctl list interface veth0-ma01
+# ovs-vsctl list interface veth0-ser01

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_groups.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_groups.yml
@@ -64,6 +64,22 @@
   with_items:
     - "{{ groups['all_service_nodes'] + groups['all_cluster_nodes'] }}"
 
+- name: add all virtual nodes to the all_virtual_nodes group
+  ansible.builtin.add_host:
+    name: "{{ item }}"
+    group: all_virtual_nodes
+  when: hostvars[item].type == 'virtual'
+  with_items:
+    - "{{ groups['all_nodes'] }}"
+
+- name: add all container nodes to the all_container_nodes group
+  ansible.builtin.add_host:
+    name: "{{ item }}"
+    group: all_container_nodes
+  when: hostvars[item].type == 'container'
+  with_items:
+    - "{{ groups['all_nodes'] }}"
+
 - name: Add all hosts to the all_hosts group
   ansible.builtin.add_host:
     name: "{{ item }}"

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_localhost.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_localhost.yml
@@ -79,4 +79,4 @@
       - '| the deployment might be broken or some distributions  |'
       - '| might not work as expected.                           |'
       - '|-------------------------------------------------------|'
-  when: kubeinit_libvirt_ovn_enabled
+  when: (groups['all_hosts'] | length > 1)

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_podman.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_podman.yml
@@ -56,36 +56,10 @@
     kubeinit_common_docker_password and
     docker_password_in_file.stat.exists
 
-- name: Dump docker.io password to a file if the password is in the variable
-  ansible.builtin.copy:
-    content: "{{ kubeinit_common_docker_password }}"
-    dest: /tmp/tmp_docker_io_pass
-  delegate_to: localhost
-  no_log: true
-  when: |
-    kubeinit_common_docker_username is defined and
-    kubeinit_common_docker_password is defined and
-    kubeinit_common_docker_username and
-    kubeinit_common_docker_password and
-    not docker_password_in_file.stat.exists
-
-- name: Read docker password from file when pass is in a variable
-  ansible.builtin.slurp:
-    src: /tmp/tmp_docker_io_pass
-  register: docker_password
-  delegate_to: localhost
-  no_log: true
-  when: |
-    kubeinit_common_docker_username is defined and
-    kubeinit_common_docker_password is defined and
-    kubeinit_common_docker_username and
-    kubeinit_common_docker_password and
-    not docker_password_in_file.stat.exists
-
 - name: Podman login to docker.io
   containers.podman.podman_login:
     username: "{{ kubeinit_common_docker_username }}"
-    password: "{{ docker_password.content | b64decode | trim }}"
+    password: "{{ (docker_password.content | b64decode | trim) if (docker_password_in_file.stat.exists) else (kubeinit_common_docker_password) }}"
     registry: "docker.io"
   no_log: true
   when: |
@@ -94,8 +68,12 @@
     kubeinit_common_docker_username and
     kubeinit_common_docker_password
 
-- name: clear any reference to docker password
+- name: Clear any reference to docker password
   ansible.builtin.set_fact:
     docker_password: null
   no_log: true
-  when: docker_password_in_file.stat.exists
+  when: |
+    kubeinit_common_docker_username is defined and
+    kubeinit_common_docker_password is defined and
+    kubeinit_common_docker_username and
+    kubeinit_common_docker_password

--- a/kubeinit/roles/kubeinit_rke/tasks/20_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/20_configure_service_nodes.yml
@@ -31,7 +31,7 @@
       containers.podman.podman_pod:
         name: "{{ kubeinit_services_pod_name }}"
         dns:
-          - "{{ kubeinit_services_service_address }}"
+          - "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
           - "{{ kubeinit_common_dns_master }}"
         dns_search: "{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }}"
         state: created


### PR DESCRIPTION
This commit removes the need for creating new files and simplifies
the flow through the prepare podman tasks.  Additional minor cleanup
changes to reduce complexity of future deliveries.