### PR TITLE
fix: retry when pods/containers fail to be created

### DIFF
--- a/kubeinit/roles/kubeinit_cdk/tasks/20_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/20_configure_service_nodes.yml
@@ -32,6 +32,10 @@
           - "{{ kubeinit_common_dns_master }}"
         dns_search: "{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }}"
         state: created
+      register: services_pod_creation
+      retries: 5
+      delay: 10
+      until: not services_pod_creation.failed
 
     # #
     # # Configure local registry

--- a/kubeinit/roles/kubeinit_eks/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/10_configure_service_nodes.yml
@@ -32,6 +32,10 @@
           - "{{ kubeinit_common_dns_master }}"
         dns_search: "{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }}"
         state: created
+      register: services_pod_creation
+      retries: 5
+      delay: 10
+      until: not services_pod_creation.failed
 
     - name: Install common requirements
       ansible.builtin.yum:

--- a/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
@@ -40,6 +40,9 @@
       - "{{ kubeinit_haproxy_config_file }}:/usr/local/etc/haproxy/haproxy.cfg"
       - "{{ kubeinit_haproxy_directory_lib }}:/var/lib/haproxy:Z"
   register: haproxy_podman_container_info
+  retries: 5
+  delay: 10
+  until: not haproxy_podman_container_info.failed
 
 - name: Setting Podman facts about the container that will run the haproxy
   ansible.builtin.set_fact:

--- a/kubeinit/roles/kubeinit_k8s/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/10_configure_service_nodes.yml
@@ -31,6 +31,10 @@
           - "{{ kubeinit_common_dns_master }}"
         dns_search: "{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }}"
         state: created
+      register: services_pod_creation
+      retries: 5
+      delay: 10
+      until: not services_pod_creation.failed
 
     - name: Install services requirements
       ansible.builtin.yum:

--- a/kubeinit/roles/kubeinit_okd/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/10_configure_service_nodes.yml
@@ -32,6 +32,10 @@
           - "{{ kubeinit_common_dns_master }}"
         dns_search: "{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }}"
         state: created
+      register: services_pod_creation
+      retries: 5
+      delay: 10
+      until: not services_pod_creation.failed
 
     - name: Render net info
       ansible.builtin.shell: |
@@ -397,6 +401,9 @@
         volumes:
           - "kubeinit-html-data:/var/kubeinit/html/"
       register: kubeinit_html_data_container_info
+      retries: 5
+      delay: 10
+      until: not kubeinit_html_data_container_info.failed
 
     - name: Copy html files into html data volume
       ansible.builtin.command: podman cp "/var/kubeinit/html/okd4/" "kubeinit-html-data-copy:/var/kubeinit/html/"

--- a/kubeinit/roles/kubeinit_registry/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/main.yml
@@ -228,6 +228,9 @@
       REGISTRY_HTTP_TLS_KEY: certs/domain.key
       REGISTRY_COMPATIBILITY_SCHEMA1_ENABLED: true
   register: registry_podman_container_info
+  retries: 5
+  delay: 10
+  until: not registry_podman_container_info.failed
 
 - name: Setting Podman facts about the container that will run the registry
   ansible.builtin.set_fact:

--- a/kubeinit/roles/kubeinit_rke/tasks/20_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/20_configure_service_nodes.yml
@@ -35,6 +35,10 @@
           - "{{ kubeinit_common_dns_master }}"
         dns_search: "{{ kubeinit_inventory_cluster_name }}.{{ kubeinit_inventory_cluster_domain }}"
         state: created
+      register: services_pod_creation
+      retries: 5
+      delay: 10
+      until: not services_pod_creation.failed
 
     - name: "Render net info"
       ansible.builtin.shell: |


### PR DESCRIPTION
WHen pulling from external sources, the pods/containers
creation might fail.

This commit adds a retry for such scenarios.

Closes: #346 