### PR TITLE
fix: allow use distro in veth interface

### DIFF
--- a/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_centos_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_centos_guest.yml
@@ -78,7 +78,7 @@
             --autostart \
             {% for net in kubeinit_libvirt_cluster_nets %}
               {% if net.enabled %}
-                --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_deployment_node_name.split("-")[1][:3] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
+                --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_inventory_cluster_distro }}{{ kubeinit_deployment_node_name.split("-")[1][:3] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
               {% endif %}
             {% endfor %}
             --graphics none \

--- a/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_coreos_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_coreos_guest.yml
@@ -86,7 +86,7 @@
             --autostart \
             {% for net in kubeinit_libvirt_cluster_nets %}
               {% if net.enabled %}
-                --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_deployment_node_name.split("-")[1][:3] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
+                --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_inventory_cluster_distro }}{{ kubeinit_deployment_node_name.split("-")[1][:3] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
               {% endif %}
             {% endfor %}
             --disk size={{ hostvars[kubeinit_deployment_node_name].disk | replace('G','') }},readonly=false \

--- a/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_ubuntu_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/60_deploy_ubuntu_guest.yml
@@ -85,7 +85,7 @@
             --autostart \
             {% for net in kubeinit_libvirt_cluster_nets %}
               {% if net.enabled %}
-                --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_deployment_node_name.split("-")[1][:3] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
+                --network network={{ net.name }}{% if net.main %},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }}{% endif %},target.dev=veth0-{{ kubeinit_inventory_cluster_distro }}{{ kubeinit_deployment_node_name.split("-")[1][:3] }}{{ kubeinit_deployment_node_name.split("-")[2] }},model=virtio \
               {% endif %}
             {% endfor %}
             --graphics none \

--- a/kubeinit/roles/kubeinit_services/tasks/00_create_service_pod.yml
+++ b/kubeinit/roles/kubeinit_services/tasks/00_create_service_pod.yml
@@ -56,7 +56,7 @@
 
 - name: Set veth facts
   ansible.builtin.set_fact:
-    ovs_veth_devname: "veth0-{{ kubeinit_deployment_node_name.split('-')[1][:3] }}{{ kubeinit_deployment_node_name.split('-')[2] }}"
+    ovs_veth_devname: "veth0-{{ kubeinit_inventory_cluster_distro }}{{ kubeinit_deployment_node_name.split('-')[1][:3] }}{{ kubeinit_deployment_node_name.split('-')[2] }}"
 
 - name: Remove any previous veth dev
   ansible.builtin.shell: |


### PR DESCRIPTION
We need to be able to deploy multiple
clusters in the same OVN network.
This commit allows to deploy two different
clusters (different distros) in the same
net.