### PR TITLE
fix: avoid cleaning networks for second cluster

### DIFF
--- a/kubeinit/roles/kubeinit_eks/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_eks/defaults/main.yml
@@ -44,7 +44,9 @@ kubeinit_eks_service_dependencies:
   - kernel-devel
   - nano
   - git
+  - podman
   - podman-docker
+  - skopeo
 
 kubeinit_eks_common_dependencies:
   - wget

--- a/kubeinit/roles/kubeinit_eks/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/10_configure_service_nodes.yml
@@ -38,6 +38,12 @@
       delay: 10
       until: not services_pod_creation.failed
 
+    - name: Prepare credentials for services
+      ansible.builtin.include_role:
+        name: ../../roles/kubeinit_services
+        tasks_from: prepare_credentials.yml
+        public: true
+
     - name: Install common requirements
       ansible.builtin.yum:
         name: "{{ kubeinit_eks_common_dependencies }}"

--- a/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
@@ -72,7 +72,6 @@ kubeinit_libvirt_source_images:
 kubeinit_libvirt_destroy_all_guests: False
 
 kubeinit_libvirt_hypervisor_tmp_dir: /tmp
-kubeinit_libvirt_destroy_nets: True
 kubeinit_libvirt_cluster_nets:
   # The following array is built with variables from the inventory
   # kimgtnet0:KubeInitManaGemenTNETwork0
@@ -87,5 +86,3 @@ kubeinit_libvirt_cluster_nets:
      type: internal,
      main: True,
      enabled: True}
-
-kubeinit_libvirt_multicluster_keep_predefined_networks: False

--- a/kubeinit/roles/kubeinit_prepare/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_prepare/defaults/main.yml
@@ -89,3 +89,10 @@ kubeinit_libvirt_hypervisor_dependencies:
     - xz-utils
     - inetutils-ping
     - libxml-xpath-perl
+
+kubeinit_libvirt_multicluster_keep_predefined_networks: False
+kubeinit_libvirt_destroy_nets: True
+
+kubeinit_prepare_podman_dependencies:
+  - podman
+  - skopeo

--- a/kubeinit/roles/kubeinit_prepare/tasks/10_cleanup.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/10_cleanup.yml
@@ -29,4 +29,5 @@
   args:
     executable: /bin/bash
   register: libvirt_clean_ovn
+  when: kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
   changed_when: "libvirt_clean_ovn.rc == 0"

--- a/kubeinit/roles/kubeinit_prepare/tasks/50_ovn_post_setup.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/50_ovn_post_setup.yml
@@ -38,6 +38,7 @@
     ovn-nbctl ls-del sw0
     ovn-nbctl --wait=hv ls-add sw0
   register: config_ovn_switch
+  when: kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
   changed_when: "config_ovn_switch.rc == 0"
 
 - name: Create the DHCP options

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_podman.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_podman.yml
@@ -15,10 +15,10 @@
 # under the License.
 
 
-- name: Install podman if required
+- name: Install common requirements
   ansible.builtin.package:
+    name: "{{ kubeinit_prepare_podman_dependencies }}"
     state: present
-    name: "podman"
 
 #
 # Currently there are two ways of configuring
@@ -61,7 +61,7 @@
     username: "{{ kubeinit_common_docker_username }}"
     password: "{{ (docker_password.content | b64decode | trim) if (docker_password_in_file.stat.exists) else (kubeinit_common_docker_password) }}"
     registry: "docker.io"
-  no_log: true
+  # no_log: true
   when: |
     kubeinit_common_docker_username is defined and
     kubeinit_common_docker_password is defined and

--- a/kubeinit/roles/kubeinit_registry/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/main.yml
@@ -39,7 +39,7 @@
     container_registry_name: "{{ registry_podman_container_info.container.Name }}"
     container_registry_pidfile: "{{ registry_podman_container_info.container.ConmonPidFile }}"
 
-- name: copy kubeinit registry secrets into registry container
+- name: Copy kubeinit registry secrets into registry container
   ansible.builtin.shell: |
     set -eo pipefail
     podman --remote cp kubeinit-credentials:/var/kubeinit/registry/auth/ - | \

--- a/kubeinit/roles/kubeinit_rke/tasks/10_configure_common.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/10_configure_common.yml
@@ -33,25 +33,25 @@
         resize2fs /dev/vda1
       changed_when: false
 
-    - name: Install Docker
-      ansible.builtin.shell: |
-        sudo apt update
-        sudo apt install apt-transport-https ca-certificates curl gnupg-agent software-properties-common -y
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-        #TODO:FIXME: uncomment when docker 20.10 is supported
-        #sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
-        sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable" -y
-        sudo apt install docker-ce={{ kubeinit_rke_docker_version }} docker-ce-cli={{ kubeinit_rke_docker_version }} containerd.io -y
-        sudo apt-mark hold docker-ce
-        # Check the available docker versions
-        # apt list -a docker-ce
-      changed_when: false
-
-    - name: Start and enable docker service
-      ansible.builtin.service:
-        name: docker
-        state: started
-        enabled: yes
+    # - name: Install Docker
+    #   ansible.builtin.shell: |
+    #     sudo apt update
+    #     sudo apt install apt-transport-https ca-certificates curl gnupg-agent software-properties-common -y
+    #     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    #     #TODO:FIXME: uncomment when docker 20.10 is supported
+    #     #sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
+    #     sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable" -y
+    #     sudo apt install docker-ce={{ kubeinit_rke_docker_version }} docker-ce-cli={{ kubeinit_rke_docker_version }} containerd.io -y
+    #     sudo apt-mark hold docker-ce
+    #     # Check the available docker versions
+    #     # apt list -a docker-ce
+    #   changed_when: false
+    #
+    # - name: Start and enable docker service
+    #   ansible.builtin.service:
+    #     name: docker
+    #     state: started
+    #     enabled: yes
 
     - name: Install kubectl
       ansible.builtin.shell: |

--- a/kubeinit/roles/kubeinit_rke/tasks/20_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/20_configure_service_nodes.yml
@@ -41,6 +41,12 @@
       delay: 10
       until: not services_pod_creation.failed
 
+    - name: Prepare credentials for services
+      ansible.builtin.include_role:
+        name: ../../roles/kubeinit_services
+        tasks_from: prepare_credentials.yml
+        public: true
+
     - name: "Render net info"
       ansible.builtin.shell: |
         set -o pipefail

--- a/kubeinit/roles/kubeinit_rke/tasks/40_configure_control_plane_nodes.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/40_configure_control_plane_nodes.yml
@@ -18,17 +18,16 @@
   block:
     - name: Install root public from service node in masters
       ansible.builtin.shell: |
-       echo "{{ kubeinit_provision_service_public_key }}" >> /root/.ssh/authorized_keys
+        echo "{{ kubeinit_provision_service_public_key }}" >> /root/.ssh/authorized_keys
       changed_when: false
-
-    - name: Enable insecure registry in Docker
-      ansible.builtin.shell: |
-        # This is mandatory so the cluster nodes can fetch the
-        # images from the local (insecure) registry
-        sed -i '/^ExecStart=/ s/$/ --insecure-registry {{ kubeinit_registry_uri }}/' /lib/systemd/system/docker.service
-        systemctl daemon-reload
-        systemctl restart docker
-      changed_when: false
-      when: kubeinit_registry_enabled|bool
-
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
+
+# This is mandatory so the cluster nodes can fetch the
+# images from the local (insecure) registry
+# - name: Enable insecure registry in Docker
+#   ansible.builtin.shell: |
+#     sed -i '/^ExecStart=/ s/$/ --insecure-registry {{ kubeinit_registry_uri }}/' /lib/systemd/system/docker.service
+#     systemctl daemon-reload
+#     systemctl restart docker
+#   changed_when: false
+#   when: kubeinit_registry_enabled|bool

--- a/kubeinit/roles/kubeinit_rke/tasks/50_configure_compute_nodes.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/50_configure_compute_nodes.yml
@@ -18,17 +18,16 @@
   block:
     - name: Install root public from service node in worker nodes
       ansible.builtin.shell: |
-       echo "{{ kubeinit_provision_service_public_key }}" >> /root/.ssh/authorized_keys
+        echo "{{ kubeinit_provision_service_public_key }}" >> /root/.ssh/authorized_keys
       changed_when: false
-
-    - name: Enable insecure registry in Docker
-      ansible.builtin.shell: |
-        # This is mandatory so the cluster nodes can fetch the
-        # images from the local (insecure) registry
-        sed -i '/^ExecStart=/ s/$/ --insecure-registry {{ kubeinit_registry_uri }}/' /lib/systemd/system/docker.service
-        systemctl daemon-reload
-        systemctl restart docker
-      changed_when: false
-      when: kubeinit_registry_enabled|bool
-
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"
+
+# This is mandatory so the cluster nodes can fetch the
+# images from the local (insecure) registry
+# - name: Enable insecure registry in Docker
+#   ansible.builtin.shell: |
+#     sed -i '/^ExecStart=/ s/$/ --insecure-registry {{ kubeinit_registry_uri }}/' /lib/systemd/system/docker.service
+#     systemctl daemon-reload
+#     systemctl restart docker
+#   changed_when: false
+#   when: kubeinit_registry_enabled|bool


### PR DESCRIPTION
This commit adds a switch to avoid cleaning the OVN
network resources when deploying a second cluster.