### PR TITLE
fix: re-enabled cdk deployment

### DIFF
--- a/kubeinit/roles/kubeinit_cdk/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_cdk/defaults/main.yml
@@ -28,3 +28,5 @@ kubeinit_cdk_common_dependencies:
   - jq
   - resolvconf
   - net-tools
+  - podman
+  - docker-compose

--- a/kubeinit/roles/kubeinit_cdk/tasks/10_configure_common.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/10_configure_common.yml
@@ -20,10 +20,30 @@
 
 - name: Configure common requirements in guests
   block:
+
+    - name: Add the Podman debian package repository to Apt
+      ansible.builtin.shell: |
+        set -eo pipefail
+        version_id=$(sed -n -e 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)
+        echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${version_id}/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+        wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_${version_id}/Release.key -O- | apt-key add -
+        apt-get update
+      args:
+        executable: /bin/bash
+      register: add_podman_repo
+      changed_when: "add_podman_repo.rc == 0"
+
     - name: Install common requirements
       ansible.builtin.package:
         name: "{{ kubeinit_cdk_common_dependencies }}"
         state: present
+
+    - name: Enable and start podman.socket
+      ansible.builtin.systemd:
+        name: podman.socket
+        enabled: yes
+        state: started
+        scope: user
 
     - name: Disable SWAP
       ansible.builtin.shell: |
@@ -36,20 +56,6 @@
         growpart /dev/vda 1
         resize2fs /dev/vda1
       changed_when: false
-
-    - name: Install Docker
-      ansible.builtin.shell: |
-        apt-get update -y
-        apt-get remove docker docker-engine docker.io -y
-        apt-get install docker.io -y
-        docker --version
-      changed_when: false
-
-    - name: Start and enable docker service
-      ansible.builtin.service:
-        name: docker
-        state: started
-        enabled: yes
 
     - name: Install kubectl
       ansible.builtin.shell: |

--- a/kubeinit/roles/kubeinit_cdk/tasks/20_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/20_configure_service_nodes.yml
@@ -38,13 +38,18 @@
       delay: 10
       until: not services_pod_creation.failed
 
+    - name: Prepare credentials for services
+      ansible.builtin.include_role:
+        name: ../../roles/kubeinit_services
+        tasks_from: prepare_credentials.yml
+        public: true
+
     # #
     # # Configure local registry
     # #
     #
     # - name: Configure a local container image registry
     #   delegate_to: "{{ groups['all_service_nodes'][0] }}"
-    #   # delegate_facts: true
     #   ansible.builtin.import_role:
     #     name: ../../roles/kubeinit_registry
     #     tasks_from: main
@@ -55,7 +60,6 @@
     #
 
     - name: Configure Bind
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_bind
         tasks_from: main
@@ -65,7 +69,6 @@
     #
 
     - name: Configure HAProxy
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_haproxy
         tasks_from: main
@@ -75,35 +78,8 @@
     #
 
     - name: Configure Apache
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_apache
         tasks_from: main
-
-    #
-    # Include the install configuration
-    #
-
-    - name: Render root keys in the service node
-      ansible.builtin.shell: |
-        set -o pipefail
-        cd
-        mkdir -p ~/.ssh
-        rm -f ~/.ssh/id_rsa && echo -e 'y\n' | ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''
-        cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-        ssh -oStrictHostKeyChecking=no 127.0.0.1 uptime
-      args:
-        executable: /bin/bash
-      register: render_service_keys
-      changed_when: "render_service_keys.rc == 0"
-
-    - name: Get root service machine public key
-      ansible.builtin.command: cat /root/.ssh/id_rsa.pub
-      register: public_key_service_content
-      changed_when: "public_key_service_content.rc == 0"
-
-    - name: Register the public key of the root service machine public key
-      ansible.builtin.set_fact:
-        kubeinit_provision_service_public_key={{ public_key_service_content.stdout }}
 
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"

--- a/kubeinit/roles/kubeinit_cdk/tasks/60_deploy_cdk.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/60_deploy_cdk.yml
@@ -34,11 +34,12 @@
         sleep 2
         ssh-keyscan {{ hostvars[groups['all_service_nodes'][0]].ansible_host }} >> ~/.ssh/known_hosts
         cd
+        cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
         snap install juju --classic
         juju add-cloud --local {{ kubeinit_inventory_cluster_name }} -f cloud.yml
         echo "bootstrapping juju..."
         juju bootstrap --no-gui \
-        --bootstrap-series=groovy \
+        --bootstrap-series=focal \
         --debug manual/root@{{ hostvars[groups['all_service_nodes'][0]].ansible_host }} > juju-bootstrap.log 2>&1
         juju controllers
         juju status --format=yaml
@@ -71,9 +72,11 @@
 
     - name: "Deploy CDK"
       ansible.builtin.shell: |
-        juju deploy ./bundle.yml --map-machines=existing{% for item in (groups['all_control_plane_nodes'] + groups['all_compute_nodes']) -%},{{ loop.index0 }}={{ loop.index0 }}{%- endfor %}
+        juju deploy ./bundle.yml --force --map-machines=existing{% for item in (groups['all_control_plane_nodes'] + groups['all_compute_nodes']) -%},{{ loop.index0 }}={{ loop.index0 }}{%- endfor %}
       register: install_cdk
       changed_when: "install_cdk.rc == 0"
+      retries: 20
+      until: install_cdk.rc == 0
 
     - name: "Get cluster status"
       ansible.builtin.shell: |
@@ -84,7 +87,7 @@
     - name: "verify that the etcd cluster is up and healthy"
       ansible.builtin.shell: |
         set -o pipefail
-        juju status | grep etcd | grep Healthy
+        juju status --format=json | sed 's/application-status/application_status/g' | jq -r .applications.etcd.application_status.message | grep Healthy
       args:
         executable: /bin/bash
       register: etcd_res
@@ -100,18 +103,21 @@
         state: directory
         mode: '0777'
 
-    - name: Make sure the kubeconfig file exists in the master node
-      ansible.builtin.stat:
-        path: ~/.kube/config
-      register: kconf_result
-      retries: 60
-      delay: 60
-      until: kconf_result.stat.exists
+    - name: Delegate to master node
+      block:
+        - name: Make sure the kubeconfig file exists in the master node
+          ansible.builtin.stat:
+            path: ~/.kube/config
+          register: kconf_result
+          retries: 60
+          delay: 60
+          until: kconf_result.stat.exists
 
-    - name: Copying the kubeconfig to a variable
-      ansible.builtin.slurp:
-        src: ~/.kube/config
-      register: kubeinit_cdk_cluster_kubeconfig
+        - name: Copying the kubeconfig to a variable
+          ansible.builtin.slurp:
+            src: ~/.kube/config
+          register: kubeinit_cdk_cluster_kubeconfig
+      delegate_to: "{{ hostvars[groups['all_control_plane_nodes'][0]].ansible_host }}"
 
     - name: Storing the master kubeconfig to the services machine.
       ansible.builtin.copy:

--- a/kubeinit/roles/kubeinit_cdk/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/main.yml
@@ -76,18 +76,18 @@
     kubeinit_deployment_node_name: "{{ cluster_role_item }}"
     kubeinit_deployment_role: worker
 
-# - name: Deploy CDK
-#   ansible.builtin.include_role:
-#     name: "../../roles/kubeinit_cdk"
-#     tasks_from: 60_deploy_cdk.yml
-#     public: yes
-#   with_items:
-#    - "{{ groups['all_service_nodes'] | list }}"
-#   loop_control:
-#     loop_var: cluster_role_item
-#   vars:
-#     kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-#     kubeinit_deployment_role: service
+- name: Deploy CDK
+  ansible.builtin.include_role:
+    name: "../../roles/kubeinit_cdk"
+    tasks_from: 60_deploy_cdk.yml
+    public: yes
+  with_items:
+    - "{{ groups['all_service_nodes'] | list }}"
+  loop_control:
+    loop_var: cluster_role_item
+  vars:
+    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    kubeinit_deployment_role: service
 
 - name: Finish post deployment tasks
   ansible.builtin.include_role:

--- a/kubeinit/roles/kubeinit_cdk/templates/bundle.yml.j2
+++ b/kubeinit/roles/kubeinit_cdk/templates/bundle.yml.j2
@@ -2,7 +2,7 @@
 # From: https://api.jujucharms.com/charmstore/v5/charmed-kubernetes/archive/bundle.yaml
 
 description: A highly-available, production-grade Kubernetes cluster.
-series: groovy
+series: focal
 machines:
 {% for item in groups['all_control_plane_nodes'] + groups['all_compute_nodes'] %}
   "{{ loop.index0 }}":
@@ -12,13 +12,13 @@ services:
     annotations:
       gui-x: '475'
       gui-y: '800'
-    charm: cs:~containers/containerd-94
+    charm: cs:~containers/containerd-130
     resources: {}
   easyrsa:
     annotations:
       gui-x: '90'
       gui-y: '420'
-    charm: cs:~containers/easyrsa-333
+    charm: cs:~containers/easyrsa-384
     constraints: root-disk=8G
     num_units: 1
     resources:
@@ -37,7 +37,7 @@ services:
     annotations:
       gui-x: '800'
       gui-y: '420'
-    charm: cs:~containers/etcd-540
+    charm: cs:~containers/etcd-594
     constraints: root-disk=8G
     num_units: {{ groups['all_control_plane_nodes'] | count }}
     options:
@@ -54,16 +54,16 @@ services:
     annotations:
       gui-x: '475'
       gui-y: '605'
-    charm: cs:~containers/flannel-506
+    charm: cs:~containers/flannel-558
     resources:
-      flannel-amd64: 646
-      flannel-arm64: 643
-      flannel-s390x: 630
+      flannel-amd64: 761
+      flannel-arm64: 758
+      flannel-s390x: 745
   kubeapi-load-balancer:
     annotations:
       gui-x: '450'
       gui-y: '250'
-    charm: cs:~containers/kubeapi-load-balancer-747
+    charm: cs:~containers/kubeapi-load-balancer-798
     constraints: mem=4G root-disk=8G
     expose: true
     num_units: 1
@@ -82,11 +82,11 @@ services:
     annotations:
       gui-x: '800'
       gui-y: '850'
-    charm: cs:~containers/kubernetes-master-891
+    charm: cs:~containers/kubernetes-master-1008
     constraints: cores=2 mem=4G root-disk=16G
     num_units: {{ groups['all_control_plane_nodes'] | count }}
     options:
-      channel: 1.19/stable
+      channel: 1.21/stable
     resources:
       cdk-addons: 0
       core: 0
@@ -104,16 +104,16 @@ services:
     annotations:
       gui-x: '90'
       gui-y: '850'
-    charm: cs:~containers/kubernetes-worker-704
+    charm: cs:~containers/kubernetes-worker-768
     constraints: cores=4 mem=4G root-disk=16G
     expose: true
     num_units: {{ groups['all_compute_nodes'] | count }}
     options:
-      channel: 1.19/stable
+      channel: 1.21/stable
     resources:
-      cni-amd64: 674
-      cni-arm64: 665
-      cni-s390x: 677
+      cni-amd64: 797
+      cni-arm64: 788
+      cni-s390x: 800
       core: 0
       kube-proxy: 0
       kubectl: 0

--- a/kubeinit/roles/kubeinit_eks/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/10_configure_service_nodes.yml
@@ -89,7 +89,6 @@
       changed_when: "render_images_list.rc == 0"
 
     - name: Configure a local container image registry
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_registry
         tasks_from: main
@@ -153,7 +152,6 @@
     #
 
     - name: Configure Bind
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_bind
         tasks_from: main
@@ -163,7 +161,6 @@
     #
 
     - name: Configure HAProxy
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_haproxy
         tasks_from: main
@@ -173,30 +170,8 @@
     #
 
     - name: Configure Apache
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_apache
         tasks_from: main
-
-    #
-    # Include the install configuration
-    #
-
-    - name: Render root keys in the service node
-      ansible.builtin.shell: |
-        cd
-        mkdir ~/.ssh
-        ssh-keygen -t rsa -N "" -f .ssh/id_rsa <<< y
-      register: render_service_keys
-      changed_when: "render_service_keys.rc == 0"
-
-    - name: Get root service machine public key
-      ansible.builtin.command: cat /root/.ssh/id_rsa.pub
-      register: public_key_service_content
-      changed_when: "public_key_service_content.rc == 0"
-
-    - name: Register the public key of the root service machine public key
-      ansible.builtin.set_fact:
-        kubeinit_provision_service_public_key={{ public_key_service_content.stdout }}
 
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"

--- a/kubeinit/roles/kubeinit_eks/tasks/50_post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/50_post_deployment_tasks.yml
@@ -47,7 +47,6 @@
   # #
   #
   # - name: Configure NFS
-  #   # delegate_facts: true
   #   ansible.builtin.import_role:
   #     name: ../../roles/kubeinit_nfs
   #     tasks_from: main

--- a/kubeinit/roles/kubeinit_k8s/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/10_configure_service_nodes.yml
@@ -37,6 +37,12 @@
       delay: 10
       until: not services_pod_creation.failed
 
+    - name: Prepare credentials for services
+      ansible.builtin.include_role:
+        name: ../../roles/kubeinit_services
+        tasks_from: prepare_credentials.yml
+        public: true
+
     - name: Install services requirements
       ansible.builtin.yum:
         name: "{{ kubeinit_k8s_service_dependencies }}"
@@ -60,7 +66,6 @@
     # #
     #
     # - name: Configure a local container image registry
-    #   # delegate_facts: true
     #   ansible.builtin.import_role:
     #     name: ../../roles/kubeinit_registry
     #     tasks_from: main
@@ -71,7 +76,6 @@
     #
 
     - name: Configure Bind
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_bind
         tasks_from: main
@@ -81,7 +85,6 @@
     #
 
     - name: Configure HAProxy
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_haproxy
         tasks_from: main
@@ -91,30 +94,8 @@
     #
 
     - name: Configure Apache
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_apache
         tasks_from: main
-
-    #
-    # Include the install configuration
-    #
-
-    - name: Render root keys in the service node
-      ansible.builtin.shell: |
-        cd
-        mkdir ~/.ssh
-        ssh-keygen -t rsa -N "" -f .ssh/id_rsa <<< y
-      register: render_service_keys
-      changed_when: "render_service_keys.rc == 0"
-
-    - name: Get root service machine public key
-      ansible.builtin.command: cat /root/.ssh/id_rsa.pub
-      register: public_key_service_content
-      changed_when: "public_key_service_content.rc == 0"
-
-    - name: Register the public key of the root service machine public key
-      ansible.builtin.set_fact:
-        kubeinit_provision_service_public_key={{ public_key_service_content.stdout }}
 
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"

--- a/kubeinit/roles/kubeinit_k8s/tasks/50_post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/50_post_deployment_tasks.yml
@@ -40,7 +40,6 @@
   # #
   #
   # - name: Configure NFS
-  #   # delegate_facts: true
   #   ansible.builtin.import_role:
   #     name: ../../roles/kubeinit_nfs
   #     tasks_from: main

--- a/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
@@ -29,7 +29,7 @@ kubeinit_libvirt_vms_default_password: asdfasdf
 
 kubeinit_libvirt_centos_release: 20210603.0
 kubeinit_libvirt_fcos_release: 33.20210117.3.2
-kubeinit_libvirt_ubuntu_release: groovy
+kubeinit_libvirt_ubuntu_release: "{{ 'focal' if (kubeinit_inventory_cluster_distro == 'cdk') else 'groovy' }}"
 
 kubeinit_libvirt_source_images:
   ubuntu:

--- a/kubeinit/roles/kubeinit_okd/tasks/prepare_virtual_services.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/prepare_virtual_services.yml
@@ -83,7 +83,6 @@
     # Configure bind
     #
     - name: Configure Bind
-      # delegate_facts: true
       ansible.builtin.include_role:
         name: ../../roles/kubeinit_bind
         public: true

--- a/kubeinit/roles/kubeinit_rke/tasks/20_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/20_configure_service_nodes.yml
@@ -86,7 +86,6 @@
       changed_when: "render_images_list.rc == 0"
 
     - name: Configure a local container image registry
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_registry
         tasks_from: main
@@ -140,7 +139,6 @@
     #
 
     - name: Configure Bind
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_bind
         tasks_from: main
@@ -150,7 +148,6 @@
     #
 
     - name: Configure HAProxy
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_haproxy
         tasks_from: main
@@ -160,33 +157,8 @@
     #
 
     - name: Configure Apache
-      # delegate_facts: true
       ansible.builtin.import_role:
         name: ../../roles/kubeinit_apache
         tasks_from: main
-
-    #
-    # Include the install configuration
-    #
-
-    - name: Render root keys in the service node
-      ansible.builtin.shell: |
-        set -o pipefail
-        cd
-        mkdir -p ~/.ssh
-        rm -f ~/.ssh/id_rsa && echo -e 'y\n' | ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''
-      args:
-        executable: /bin/bash
-      register: render_service_keys
-      changed_when: "render_service_keys.rc == 0"
-
-    - name: Get root service machine public key
-      ansible.builtin.command: cat /root/.ssh/id_rsa.pub
-      register: public_key_service_content
-      changed_when: "public_key_service_content.rc == 0"
-
-    - name: Register the public key of the root service machine public key
-      ansible.builtin.set_fact:
-        kubeinit_provision_service_public_key={{ public_key_service_content.stdout }}
 
   delegate_to: "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}"

--- a/kubeinit/roles/kubeinit_rke/tasks/70_post_deployment_services_tasks.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/70_post_deployment_services_tasks.yml
@@ -21,7 +21,6 @@
     # #
     #
     # - name: Configure NFS
-    #   # delegate_facts: true
     #   ansible.builtin.import_role:
     #     name: ../../roles/kubeinit_nfs
     #     tasks_from: main


### PR DESCRIPTION
This commit restores the cdk support to an operational
state.  There are some configurations that still have
some issues, but the cluster deployments should function
again and the cluster issues can be investigated further.