### PR TITLE
fix: make sure PK has the correct perms

### DIFF
--- a/kubeinit/roles/kubeinit_eks/tasks/30_configure_control_plane_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/30_configure_control_plane_nodes.yml
@@ -18,7 +18,9 @@
   block:
     - name: Install root public from service node in master nodes
       ansible.builtin.shell: |
-       echo "{{ kubeinit_provision_service_public_key }}" >> /root/.ssh/authorized_keys
+        echo "{{ kubeinit_provision_service_public_key }}" >> ~/.ssh/authorized_keys
+        # Make sure the private key has the correct perms
+        chmod 600 ~/.ssh/id_rsa
       changed_when: false
 
     # Push the certificates from the registry to the master nodes if its enabled


### PR DESCRIPTION
This commit makes sure the EKS distro has the correct perms in
the OK before referencing it.