### PR TITLE
fix: make sure PK has the correct perms

### DIFF
--- a/kubeinit/roles/kubeinit_eks/tasks/10_configure_service_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/10_configure_service_nodes.yml
@@ -147,6 +147,16 @@
       changed_when: "mirror_registry.rc == 0"
       when: kubeinit_registry_enabled|bool
 
+    - name: Make sure the PK has the correct permissions
+      ansible.builtin.shell: |
+        set -o pipefail
+        # Make sure the private key has the correct perms
+        chmod 600 ~/.ssh/id_rsa
+      args:
+        executable: /bin/bash
+      register: ssh_correct_perms
+      changed_when: "ssh_correct_perms.rc == 0"
+
     #
     # Configure bind
     #

--- a/kubeinit/roles/kubeinit_eks/tasks/30_configure_control_plane_nodes.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/30_configure_control_plane_nodes.yml
@@ -19,8 +19,6 @@
     - name: Install root public from service node in master nodes
       ansible.builtin.shell: |
         echo "{{ kubeinit_provision_service_public_key }}" >> ~/.ssh/authorized_keys
-        # Make sure the private key has the correct perms
-        chmod 600 ~/.ssh/id_rsa
       changed_when: false
 
     # Push the certificates from the registry to the master nodes if its enabled


### PR DESCRIPTION
This commit makes sure the EKS distro has the correct perms in
the OK before referencing it.