### PR TITLE
fix: set Ansible shell to Bash when using pipefail

### DIFF
--- a/kubeinit/roles/kubeinit_prepare/tasks/50_ovn_post_setup.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/50_ovn_post_setup.yml
@@ -166,6 +166,8 @@
     iptables -P FORWARD ACCEPT
     iptables -P INPUT ACCEPT
     iptables -P OUTPUT ACCEPT
+  args:
+    executable: /bin/bash
   register: config_iptables
   changed_when: "config_iptables.rc == 0"
 

--- a/kubeinit/roles/kubeinit_services/tasks/00_create_service_pod.yml
+++ b/kubeinit/roles/kubeinit_services/tasks/00_create_service_pod.yml
@@ -62,6 +62,8 @@
   ansible.builtin.shell: |
     set -eo pipefail
     ip link del {{ ovs_veth_devname }} || true
+  args:
+    executable: /bin/bash
   register: remove_veth_dev
   changed_when: "remove_veth_dev.rc == 0"
 

--- a/kubeinit/roles/kubeinit_services/tasks/10_create_provision_container.yml
+++ b/kubeinit/roles/kubeinit_services/tasks/10_create_provision_container.yml
@@ -63,6 +63,8 @@
     then
       buildah rm buildah-services
     fi
+  args:
+    executable: /bin/bash
   register: services_buildah_rm_img
   changed_when: "services_buildah_rm_img.rc == 0"
 

--- a/kubeinit/roles/kubeinit_services/tasks/prepare_credentials.yml
+++ b/kubeinit/roles/kubeinit_services/tasks/prepare_credentials.yml
@@ -55,6 +55,8 @@
   ansible.builtin.shell: |
     set -eo pipefail
     ssh -O exit -S "/root/.ssh/cm-%r@%h:%p" "{{ hostvars[kubeinit_deployment_node_name].ansible_host }}" || true
+  args:
+    executable: /bin/bash
   delegate_to: "{{ kubeinit_bastion_host_address }}"
   when: hostvars[kubeinit_deployment_node_name].type == 'virtual'
 
@@ -72,6 +74,8 @@
   ansible.builtin.shell: |
     set -eo pipefail
     podman --remote system connection remove "{{ kubeinit_deployment_node_name }}" || true
+  args:
+    executable: /bin/bash
   delegate_to: localhost
   register: remove_remote_connection
   changed_when: "remove_remote_connection.rc == 0"
@@ -138,10 +142,10 @@
       ansible.builtin.shell: |
         set -o pipefail
         python3 -m pip install cryptography==3.3.2 passlib
-      register: install_passlib
-      changed_when: "install_passlib.rc == 0"
       args:
         executable: /bin/bash
+      register: install_passlib
+      changed_when: "install_passlib.rc == 0"
 
     - name: Create directory to hold the registry files
       ansible.builtin.file:


### PR DESCRIPTION
pipefail is not present within the sh shell and produces the following error message:

```
Illegal option -o pipefail
``` 