### PR TITLE
fix: use k8s 1.2 in OKD 4.7

### DIFF
--- a/kubeinit/hosts/cdk/inventory
+++ b/kubeinit/hosts/cdk/inventory
@@ -25,7 +25,7 @@ kubeinit_inventory_cluster_distro=cdk
 kubeinit_inventory_cluster_name=cdkcluster
 kubeinit_inventory_cluster_domain=kubeinit.local
 
-kubeinit_inventory_k8s_version=do_not_remove
+kubeinit_inventory_k8s_version="do_not_remove"
 
 [control_plane_nodes:vars]
 os=ubuntu

--- a/kubeinit/hosts/eks/inventory
+++ b/kubeinit/hosts/eks/inventory
@@ -25,7 +25,7 @@ kubeinit_inventory_cluster_distro=eks
 kubeinit_inventory_cluster_name=ekscluster
 kubeinit_inventory_cluster_domain=kubeinit.local
 
-kubeinit_inventory_k8s_version=1.18
+kubeinit_inventory_k8s_version="1.18"
 
 [control_plane_nodes:vars]
 os=centos

--- a/kubeinit/hosts/k8s/inventory
+++ b/kubeinit/hosts/k8s/inventory
@@ -25,7 +25,7 @@ kubeinit_inventory_cluster_distro=k8s
 kubeinit_inventory_cluster_name=k8scluster
 kubeinit_inventory_cluster_domain=kubeinit.local
 
-kubeinit_inventory_k8s_version=1.21
+kubeinit_inventory_k8s_version="1.21"
 
 [control_plane_nodes:vars]
 os=centos

--- a/kubeinit/hosts/kid/inventory
+++ b/kubeinit/hosts/kid/inventory
@@ -25,7 +25,7 @@ kubeinit_inventory_cluster_distro=kid
 kubeinit_inventory_cluster_name=kidcluster
 kubeinit_inventory_cluster_domain=kubeinit.local
 
-kubeinit_inventory_k8s_version=do_not_remove
+kubeinit_inventory_k8s_version="do_not_remove"
 
 [control_plane_nodes:vars]
 os=debian

--- a/kubeinit/hosts/okd/inventory
+++ b/kubeinit/hosts/okd/inventory
@@ -25,7 +25,7 @@ kubeinit_inventory_cluster_distro=okd
 kubeinit_inventory_cluster_name=okdcluster
 kubeinit_inventory_cluster_domain=kubeinit.local
 
-kubeinit_inventory_k8s_version=do_not_remove
+kubeinit_inventory_k8s_version="1.20"
 
 [control_plane_nodes:vars]
 os=coreos


### PR DESCRIPTION
This commit adds the 1.20 repos for cri-o
in OKD 4.7