### PR TITLE
fix: run the e2e test as the runner user

### DIFF
--- a/.github/workflows/distro_test.yml
+++ b/.github/workflows/distro_test.yml
@@ -80,6 +80,10 @@ jobs:
         ansible-galaxy collection install --force -r kubeinit/requirements.yml
         # Run the playbook
         ansible-playbook \
-            -v -i ./hosts/cdk/inventory \
+            -v \
+            --user runner \
+            --become \
+            --become-user root \
+            -i ./hosts/cdk/inventory \
             ./playbooks/cdk.yml \
             --check || true


### PR DESCRIPTION
This commit makes the playbook to run as
the runner user.