### PR TITLE
fix: move tasks to gather hypervisor facts out of hypervisor_hosts play

### DIFF
--- a/kubeinit/playbook.yml
+++ b/kubeinit/playbook.yml
@@ -27,6 +27,22 @@
         that: "ansible_version.full is version_compare('{{ kubeinit_ansible_min_version }}', '>=')"
         msg: >
           "You must update Ansible to at least {{ kubeinit_ansible_min_version }} to use KubeInit."
+  tasks:
+    - name: task-gather-hypervisor-facts
+      ansible.builtin.include_role:
+        name: "../../roles/kubeinit_prepare"
+        tasks_from: gather_host_facts.yml
+        public: true
+      with_items:
+        - "{{ groups['hypervisor_hosts'] | list }}"
+      loop_control:
+        loop_var: cluster_role_item
+      vars:
+        kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    - name: Check to see if we should stop here
+      ansible.builtin.fail:
+        msg: "Stopping after 'task-gather-hypervisor-facts'"
+      when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task == 'task-gather-hypervisor-facts'
 
 - name: Prepare all hypervisor hosts to deploy service and cluster nodes
   hosts: hypervisor_hosts
@@ -37,10 +53,6 @@
         name: "../../roles/kubeinit_prepare"
         tasks_from: prepare_hypervisor.yml
         public: true
-    - name: Check to see if we should stop here
-      ansible.builtin.fail:
-        msg: "Stopping after 'task-prepare-hypervisor'"
-      when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task == 'task-prepare-hypervisor'
 
 - name: Main deployment play for creating a cluster
   hosts: localhost

--- a/kubeinit/roles/kubeinit_prepare/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/main.yml
@@ -32,10 +32,15 @@
 
     - name: Check to see if we should stop here
       ansible.builtin.fail:
-        msg: "Stopping after 'task-prepare-hypervisor'"
-      when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task == 'task-prepare-hypervisor'
+        msg: "Stopping after 'task-gather-hypervisor-facts'"
+      when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task == 'task-gather-hypervisor-facts'
 
   when: not hypervisor_facts_set
+
+- name: Check to see if we should stop here
+  ansible.builtin.fail:
+    msg: "Stopping after 'task-prepare-hypervisor'"
+  when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task == 'task-prepare-hypervisor'
 
 - name: Add localhost to the local_host group
   ansible.builtin.add_host:

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_hypervisor.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_hypervisor.yml
@@ -19,11 +19,6 @@
 # Prepare the hypervisor
 #
 
-- name: Gather network and hosts facts from hypervisor
-  ansible.builtin.include_tasks: gather_host_facts.yml
-  vars:
-    kubeinit_deployment_node_name: "{{ inventory_hostname }}"
-
 - name: Delegate to kubeinit_deployment_node_name (inventory_hostname)
   block:
 


### PR DESCRIPTION
Side-effect is there is now a new play task to start and stop on: `task-gather-hypervisor-facts`