### PR TITLE
perf: optimize dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ LABEL quay.expires-after=30w
 
 WORKDIR /kubeinit
 
-COPY . .
 
 # Overrides SSH Hosts Checking
 RUN set -x && \
@@ -28,7 +27,12 @@ RUN set -x && \
         shyaml \
         cryptography==3.3.2 \
         ansible==3.4.0 \
-        netaddr && \
+        netaddr
+
+
+COPY . .
+
+RUN set -x && \
     \
     echo "==> Installing KubeInit..."  && \
     cd ./kubeinit && \


### PR DESCRIPTION
By moving the the COPY directive to a lower position, we can save
rebuilds of the container when we are actively working on the code.

As the packages are installed before the copy directive, the base
container needs to be built only once.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>