### PR TITLE
fix: make firewalld consistent across HVs

### DIFF
--- a/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
@@ -174,6 +174,7 @@ kubeinit_libvirt_hypervisor_dependencies:
     - inetutils-ping
     - libxml-xpath-perl
     - jq
+    - firewalld
 
 kubeinit_libvirt_multicluster_keep_predefined_networks: False
 kubeinit_libvirt_destroy_nets: True

--- a/kubeinit/roles/kubeinit_libvirt/tasks/20_ovn_install.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/20_ovn_install.yml
@@ -34,7 +34,10 @@
   when: >
     (kubeinit_deployment_node_name in kubeinit_ovn_central_host) and
     (hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS')
-  changed_when: false
+  args:
+    executable: /bin/bash
+  register: ovn_install
+  changed_when: "ovn_install.rc == 0"
 
 - name: Install OVN packages in Fedora (Master Hypervisor)
   ansible.builtin.shell: |
@@ -47,7 +50,10 @@
   when: >
     (kubeinit_deployment_node_name in kubeinit_ovn_central_host) and
     (hostvars[kubeinit_deployment_node_name].distribution_family == 'Fedora')
-  changed_when: false
+  args:
+    executable: /bin/bash
+  register: ovn_install
+  changed_when: "ovn_install.rc == 0"
 
 - name: Install OVN packages in Ubuntu/Debian (Master Hypervisor)
   ansible.builtin.shell: |
@@ -59,7 +65,10 @@
   when: >
     (kubeinit_deployment_node_name in kubeinit_ovn_central_host) and
     (hostvars[kubeinit_deployment_node_name].distribution_family == 'Debian')
-  changed_when: false
+  args:
+    executable: /bin/bash
+  register: ovn_install
+  changed_when: "ovn_install.rc == 0"
 
 #
 # We DO NOT install ovn-central (OVN requirement) in the other hypervisors
@@ -76,7 +85,10 @@
   when: >
     (kubeinit_deployment_node_name not in kubeinit_ovn_central_host) and
     (hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS')
-  changed_when: false
+  args:
+    executable: /bin/bash
+  register: ovn_install_slaves
+  changed_when: "ovn_install_slaves.rc == 0"
 
 - name: Install OVN packages in Fedora (Slave Hypervisor)
   ansible.builtin.shell: |
@@ -88,7 +100,10 @@
   when: >
     (kubeinit_deployment_node_name not in kubeinit_ovn_central_host) and
     (hostvars[kubeinit_deployment_node_name].distribution_family == 'Fedora')
-  changed_when: false
+  args:
+    executable: /bin/bash
+  register: ovn_install_slaves
+  changed_when: "ovn_install_slaves.rc == 0"
 
 - name: Install OVN packages in Ubuntu/Debian (Slave Hypervisor)
   ansible.builtin.shell: |
@@ -99,13 +114,18 @@
   when: >
     (kubeinit_deployment_node_name not in kubeinit_ovn_central_host) and
     (hostvars[kubeinit_deployment_node_name].distribution_family == 'Debian')
-  changed_when: false
+  args:
+    executable: /bin/bash
+  register: ovn_install_slaves
+  changed_when: "ovn_install_slaves.rc == 0"
 
 - name: Refresh firewalld services list to pick up ovn services
   ansible.builtin.shell: |
     firewall-cmd --reload
-  when: >
-    (hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS')
+  args:
+    executable: /bin/bash
+  register: refresh_firewalld
+  changed_when: "refresh_firewalld.rc == 0"
 
 - name: Enable OVN central in firewalld
   ansible.posix.firewalld:
@@ -114,8 +134,7 @@
     state: enabled
     immediate: true
   when: >
-    (kubeinit_deployment_node_name in kubeinit_ovn_central_host) and
-    (hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS')
+    (kubeinit_deployment_node_name in kubeinit_ovn_central_host)
 
 - name: Enable OVN NAT in firewalld
   ansible.posix.firewalld:
@@ -124,8 +143,7 @@
     state: enabled
     immediate: true
   when: >
-    (kubeinit_deployment_node_name in kubeinit_ovn_central_host) and
-    (hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS')
+    (kubeinit_deployment_node_name in kubeinit_ovn_central_host)
 
 - name: Enable OVN host in firewalld
   ansible.posix.firewalld:
@@ -133,14 +151,14 @@
     permanent: true
     state: enabled
     immediate: true
-  when: >
-    (hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS')
 
 - name: Refresh firewalld services list
   ansible.builtin.shell: |
     firewall-cmd --reload
-  when: >
-    (hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS')
+  args:
+    executable: /bin/bash
+  register: refresh_firewalld_s
+  changed_when: "refresh_firewalld_s.rc == 0"
 
 - name: Enable and start OVN services in the first hypervisor (CentOS based)
   ansible.builtin.service:

--- a/kubeinit/roles/kubeinit_libvirt/tasks/50_ovn_post_setup.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/50_ovn_post_setup.yml
@@ -145,7 +145,7 @@
     executable: /bin/bash
   register: config_iptables
   changed_when: "config_iptables.rc == 0"
-
+  when: false  # This task is disabled as the rules are managed by firewalld
 # When the deployment finishes, it shuold be possible to see the available chassis and ports by running:
 # ovn-nbctl show
 # ovn-sbctl show

--- a/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
@@ -162,6 +162,12 @@
     state: present
   when: intel_processor.rc == 0 or amd_processor.rc == 0
 
+- name: Enable and start firewalld
+  ansible.builtin.service:
+    name: firewalld
+    enabled: yes
+    state: started
+
 - name: Enable and start libvirtd
   ansible.builtin.service:
     name: libvirtd


### PR DESCRIPTION
This commit makes consistent the usage of
firewalld across the OS distributions
supported in the HVs.