### PR TITLE
ci: fix lines spaces

### DIFF
--- a/ci/periodic_jobs.md.j2
+++ b/ci/periodic_jobs.md.j2
@@ -14,6 +14,6 @@
 
 | Distribution     | Scenario/State | Driver           | Controllers       | Computes          | Hypervisors           | Services type           | Launch from          |
 |------------------|----------------|------------------|-------------------|-------------------|-----------------------|-------------------------|----------------------|
-{%- for job in jobs -%}
+{%- for job in jobs %}
 | {{ job.distro }} | {{ job.url }} | {{ job.driver }} | {{ job.masters }} | {{ job.workers }} | {{ job.hypervisors }} | {{ job.services_type }} | {{ job.launch_from }} |
-{%- endfor -%}
+{%- endfor %}


### PR DESCRIPTION
This commit fixes the periodic job status page newlines.