### PR TITLE
ci: add label info to periodic jobs

### DIFF
--- a/ci/launch_e2e.py
+++ b/ci/launch_e2e.py
@@ -329,7 +329,13 @@ def run_e2e_job(distro, driver, masters, workers,
                 branch_name, pr_number, launch_from, job_name):
     """Run the e2e job."""
     output = 0
-    badge_text = "build"
+    badge_text = "%s-%s-%s-%s-%s-%s-%s" % (distro,
+                                           driver,
+                                           masters,
+                                           workers,
+                                           hypervisors,
+                                           services,
+                                           launch_from)
     badge_code = badge(left_text=badge_text,
                        right_text='passing',
                        right_color='green')

--- a/ci/periodic_jobs.md.j2
+++ b/ci/periodic_jobs.md.j2
@@ -12,8 +12,8 @@
 
 # Periodic jobs status
 
-| Distribution     | Status        | Driver           | Controllers       | Computes          | Hypervisors           | Services type           | Launch from          |
-|------------------|---------------|------------------|-------------------|-------------------|-----------------------|-------------------------|----------------------|
+| Distribution     | Label/Status  | Driver           | Controllers       | Computes          | Hypervisors           | Services type           | Launch from           |
+|------------------|---------------|------------------|-------------------|-------------------|-----------------------|-------------------------|-----------------------|
 {%- for job in jobs %}
 | {{ job.distro }} | {{ job.url }} | {{ job.driver }} | {{ job.masters }} | {{ job.workers }} | {{ job.hypervisors }} | {{ job.services_type }} | {{ job.launch_from }} |
 {%- endfor %}


### PR DESCRIPTION
This commit adds some context information
for the labels used in the CI for checking
PRs.