### PR TITLE
fix: make cluster changes based on firewalld status

### DIFF
--- a/ci/install_gitlab_node.sh
+++ b/ci/install_gitlab_node.sh
@@ -50,17 +50,28 @@ if [ -f /etc/redhat-release ] || [ -f /etc/fedora-release ]; then
     fi
 fi
 
-sudo python3 -m pip install --upgrade pip
-sudo python3 -m pip install --upgrade setuptools
-sudo python3 -m pip install requests
-sudo python3 -m pip install setuptools_rust
-sudo python3 -m pip install shyaml
-sudo python3 -m pip install ansible
-sudo python3 -m pip install PyGithub
-sudo python3 -m pip install netaddr
-sudo python3 -m pip install pybadges
-sudo python3 -m pip install jinja2
-sudo python3 -m pip install google-cloud-storage
+# Make sure ansible is removed
+if command -v ansible; then
+    apath=$(python3 -m pip show ansible | grep Location | awk '{ print $2 }')
+    python3 -m pip uninstall ansible -y
+    sudo rm -rf "$apath/ansible*"
+fi
+
+# Install dependencies
+python3 -m pip install \
+    --upgrade \
+    pip \
+    wheel \
+    shyaml \
+    cryptography==3.3.2 \
+    ansible==3.4.0 \
+    netaddr \
+    requests \
+    PyGithub \
+    pybadges \
+    jinja2 \
+    urllib3 \
+    google-cloud-storage
 
 # Install and configure ara
 # There are problems with multithread ara, we keep the last

--- a/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
@@ -145,7 +145,6 @@ kubeinit_libvirt_hypervisor_dependencies:
     - iptables-services
     - net-tools
     - xz
-    - firewalld
     - perl-XML-XPath
   debian:
     - sudo

--- a/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
@@ -167,15 +167,6 @@
     intel_processor: null
     amd_processor: null
 
-- name: Make sure firewalld is started and enabled in CentOS/Fedora/RHEL
-  ansible.builtin.service:
-    name: firewalld
-    enabled: yes
-    state: started
-  when: >
-    (hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS') or
-    (hostvars[kubeinit_deployment_node_name].distribution_family == 'Fedora')
-
 - name: Enable and start libvirtd
   ansible.builtin.service:
     name: libvirtd

--- a/kubeinit/roles/kubeinit_prepare/tasks/gather_host_facts.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/gather_host_facts.yml
@@ -23,37 +23,51 @@
         gather_subset: "!all,network"
       register: gather_results
 
+    - name: Gather the services facts
+      ansible.builtin.service_facts:
+      register: services_results
+
+    # - name: Print the services facts
+    #   ansible.builtin.debug:
+    #     var: services_results
+
+    - name: Set firewalld_state to unknown
+      ansible.builtin.set_fact:
+        firewalld_state: 'unknown'
+
+    - name: Set firewalld_state when firewalld is defined
+      ansible.builtin.set_fact:
+        firewalld_state: "{{ services_results.ansible_facts.services['firewalld'].state }}"
+      when: services_results.ansible_facts.services['firewalld'] is defined
+
+    - name: Set firewalld_state when firewalld.service is defined
+      ansible.builtin.set_fact:
+        firewalld_state: "{{ services_results.ansible_facts.services['firewalld.service'].state }}"
+      when: services_results.ansible_facts.services['firewalld.service'] is defined
+
+    - name: Set firewalld_active
+      ansible.builtin.set_fact:
+        firewalld_active: "{{ true if firewalld_state == 'running' else false }}"
+
     - name: Set distro_family for CentOS
       ansible.builtin.set_fact:
         distro_family: "CentOS"
-        firewalld_active: true
       when: (gather_results.ansible_facts.ansible_distribution == 'CentOS' or gather_results.ansible_facts.ansible_distribution == 'RedHat')
 
     - name: Set distro_family for Fedora
       ansible.builtin.set_fact:
         distro_family: "Fedora"
-        firewalld_active: true
       when: (gather_results.ansible_facts.ansible_distribution == 'Fedora')
 
     - name: Set distro_family for Debian
       ansible.builtin.set_fact:
         distro_family: "Debian"
-        firewalld_active: false
       when: (gather_results.ansible_facts.ansible_distribution == 'Debian' or gather_results.ansible_facts.ansible_distribution == 'Ubuntu')
 
     - name: Fails if OS is not supported
       ansible.builtin.fail:
         msg: "The host \"{{ kubeinit_deployment_node_host }}\" needs to be CentOS/RHEL, Fedora, or Debian/Ubuntu"
       when: not distro_family is defined
-
-    # TODO: use this when we are ready to adjust to existing firewall behavior
-    # - name: See if firewalld is active
-    #   ansible.builtin.command:
-    #     systemctl is-active firewalld
-    #   register: check_firewalld
-    #   failed_when:
-    #     - check_firewalld.rc != 0
-    #     - check_firewalld.rc != 3
 
     - name: Add ansible facts to hostvars
       ansible.builtin.add_host:
@@ -64,7 +78,6 @@
         ansible_distribution_major_version: "{{ gather_results.ansible_facts.ansible_distribution_major_version }}"
         distribution_family: "{{ distro_family }}"
         firewalld_is_active: "{{ firewalld_active }}"
-        # firewalld_is_active: "{{ true if (check_firewalld.rc == 0) else false }}"
 
     - name: Clear gather_results
       ansible.builtin.set_fact:

--- a/kubeinit/roles/kubeinit_services/tasks/prepare_credentials.yml
+++ b/kubeinit/roles/kubeinit_services/tasks/prepare_credentials.yml
@@ -62,7 +62,7 @@
     state: enabled
     immediate: true
   delegate_to: "{{ kubeinit_bastion_host_address }}"
-  when: hostvars[kubeinit_bastion_host].distribution_family == 'CentOS'
+  when: hostvars[kubeinit_bastion_host].firewalld_is_active
 
 - name: Reload firewalld service
   ansible.builtin.systemd:
@@ -71,7 +71,7 @@
   environment:
     DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
   delegate_to: "{{ kubeinit_bastion_host_address }}"
-  when: hostvars[kubeinit_bastion_host].distribution_family == 'CentOS'
+  when: hostvars[kubeinit_bastion_host].firewalld_is_active
 
 - name: Set ssh port to use
   ansible.builtin.set_fact:


### PR DESCRIPTION
We should not install or force firewalld status
to configure the cluster, this commit check the
firewalld status before executing the tasks.