### PR TITLE
fix: increase timeout for CDK deployments

### DIFF
--- a/kubeinit/roles/kubeinit_cdk/tasks/60_deploy_cdk.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/60_deploy_cdk.yml
@@ -105,7 +105,7 @@
         executable: /bin/bash
       register: etcd_res
       changed_when: "etcd_res.rc == 0"
-      retries: 60
+      retries: 100
       delay: 60
       until: "'Healthy with {{ groups['all_controller_nodes'] | count | string }} known peer' in etcd_res.stdout"
 


### PR DESCRIPTION
This commit increases the timeout when waiting
for the cluster to converge, this is useful when
deploying in old HW so the cluster will take
more time to be healthy.