### PR TITLE
ci: do not update the .md job page

### DIFF
--- a/ci/kubeinit_ci_utils.py
+++ b/ci/kubeinit_ci_utils.py
@@ -70,11 +70,18 @@ def render_index(gc_token_path):
 
         extra_data_date_url = 'https://storage.googleapis.com/kubeinit-ci/jobs/' + blob + '/records/1.html'
         resp = requests.get(url=extra_data_date_url)
-        m = re.search('[0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]:[0-9][0-9]:[0-9][0-9]', resp.text)
+
+        m = re.search("[0-9][0-9][0-9][0-9]\\.[0-9][0-9]\\.[0-9][0-9]\\.[0-9][0-9]\\.[0-9][0-9]\\.[0-9][0-9]", resp.text)
         if m and status == "Periodic":
             date = m.group(0)
         else:
             date = fields[9]
+
+        m = re.search("https:\\/\\/gitlab\\.com\\/kubeinit\\/kubeinit\\/-\\/jobs\\/[0-9]+", resp.text)
+        if m and status == "Periodic":
+            job_id = m.group(0).split('/')[-1]
+        else:
+            job_id = fields[9]
 
         jobs.append({'status': status,
                      'index': idx,
@@ -86,7 +93,7 @@ def render_index(gc_token_path):
                      'services_type': fields[5],
                      'launch_from': fields[6],
                      'job_type': fields[7],
-                     'id': fields[8],
+                     'id': job_id,
                      'date': date,
                      'badge': badge,
                      'url': 'https://storage.googleapis.com/kubeinit-ci/jobs/' + blob + '/index.html'})

--- a/ci/launch_e2e.sh
+++ b/ci/launch_e2e.sh
@@ -298,7 +298,7 @@ KUBEINIT_REVISION="${revision:-ci}" python3 -m pip install --upgrade ./agent
 
 kubeinit -b > ./kubeinit/playbooks/aux_info_file.txt
 echo "" >> ./kubeinit/playbooks/aux_info_file.txt
-echo "(launch_e2e.sh) ==> Date: $(date +"%y-%m-%d_%T")" >> ./kubeinit/playbooks/aux_info_file.txt
+echo "(launch_e2e.sh) ==> Date: $(date +"%Y.%m.%d.%H.%M.%S")" >> ./kubeinit/playbooks/aux_info_file.txt
 echo "(launch_e2e.sh) ==> Kubeinit agent/cli version: $(kubeinit -v) " >> ./kubeinit/playbooks/aux_info_file.txt
 echo "(launch_e2e.sh) ==> The repository is: ${REPOSITORY}" >> ./kubeinit/playbooks/aux_info_file.txt
 echo "(launch_e2e.sh) ==> The branch is: ${BRANCH_NAME}" >> ./kubeinit/playbooks/aux_info_file.txt

--- a/ci/periodic_jobs.md.j2
+++ b/ci/periodic_jobs.md.j2
@@ -12,10 +12,10 @@
 
 # Periodic jobs status
 
-| Distribution     | Label/Status  | Driver           | Controllers       | Computes          | Hypervisors           | Services type           | Launch from           | Date           |
-|------------------|---------------|------------------|-------------------|-------------------|-----------------------|-------------------------|-----------------------|----------------|
+| Distribution     | Label/Status  | Driver           | Controllers       | Computes          | Hypervisors           | Services type           | Launch from           |
+|------------------|---------------|------------------|-------------------|-------------------|-----------------------|-------------------------|-----------------------|
 {%- for job in jobs %}
-| {{ job.distro }} | {{ job.url }} | {{ job.driver }} | {{ job.masters }} | {{ job.workers }} | {{ job.hypervisors }} | {{ job.services_type }} | {{ job.launch_from }} | {{ job.date }} |
+| {{ job.distro }} | {{ job.url }} | {{ job.driver }} | {{ job.masters }} | {{ job.workers }} | {{ job.hypervisors }} | {{ job.services_type }} | {{ job.launch_from }} |
 {%- endfor %}
 
 The content of this page is rendered from each job label defined

--- a/ci/render_periodic_jobs_page.py
+++ b/ci/render_periodic_jobs_page.py
@@ -23,8 +23,6 @@ from jinja2 import Environment, FileSystemLoader
 
 from kubeinit_ci_utils import get_periodic_jobs_labels
 
-import requests
-
 
 def main():
     """Run the main method."""
@@ -74,14 +72,6 @@ def main():
             print(label)
             raise Exception("'render_periodic_jobs_page.py' ==> This label do not match: %s" % (label))
 
-        extra_data_date_url = 'https://storage.googleapis.com/kubeinit-ci/jobs/' + label + '-periodic-pid-weekly-u/records/1.html'
-        resp = requests.get(url=extra_data_date_url)
-        m = re.search('[0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]:[0-9][0-9]:[0-9][0-9]', resp.text)
-        if m:
-            date = m.group(0)
-        else:
-            date = 'undefined'
-
         jobs.append({'distro': distro,
                      'driver': driver,
                      'masters': masters,
@@ -89,7 +79,6 @@ def main():
                      'hypervisors': hypervisors,
                      'services_type': services_type,
                      'launch_from': launch_from,
-                     'date': date,
                      'url': "<a href='https://storage.googleapis.com/kubeinit-ci/jobs/" + label + "-periodic-pid-weekly-u/index.html'><img height='20px' src='https://storage.googleapis.com/kubeinit-ci/jobs/" + label + "-periodic-pid-weekly-u/badge_status.svg'/></a>"})
 
     path = os.path.join(os.path.dirname(__file__))


### PR DESCRIPTION
This commit revert adding the job dates in the
GItHub job page, this is because then after
every job execution the page will be re-rendered
creating continous pull requests.