### PR TITLE
docs: include end-to-end workflow

### DIFF
--- a/.github/workflows/docs_build_pr.yml
+++ b/.github/workflows/docs_build_pr.yml
@@ -16,10 +16,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Render the projects roles and inventory diagrams
+      - name: Install required packages
         run: |
           sudo apt-get update -y
-          sudo apt-get install graphviz -y
+          sudo apt-get install graphviz plantuml openjdk-11-jdk -y
           sudo apt-get remove ansible -y
           sudo python3 -m pip uninstall ansible
           sudo python3 -m pip install ansible==3.4.0
@@ -29,6 +29,14 @@ jobs:
           sudo python3 -m pip install --upgrade ansible-inventory-grapher
           sudo python3 -m pip install --upgrade ansible-playbook-grapher
 
+      - name: Render the plantuml diagrams
+        run: |
+          plantuml -tsvg -output render ./docs/src/images/plantuml/*.plantuml
+          mkdir -p ./docs/src/static/plantuml
+          mv ./docs/src/images/plantuml/render/* ./docs/src/static/plantuml/
+
+      - name: Render the projects roles and inventory diagrams
+        run: |
           distros=()
           for p in ./hosts/*/
           do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Render the projects roles and inventory diagrams
+      - name: Install required packages
         run: |
-          sudo apt-get install graphviz -y
+          sudo apt-get update -y
+          sudo apt-get install graphviz plantuml openjdk-11-jdk -y
           sudo apt-get remove ansible -y
           sudo python3 -m pip uninstall ansible
           sudo python3 -m pip install ansible==3.4.0
@@ -93,6 +94,14 @@ jobs:
           sudo python3 -m pip install --upgrade ansible-inventory-grapher
           sudo python3 -m pip install --upgrade ansible-playbook-grapher
 
+      - name: Render the plantuml diagrams
+        run: |
+          plantuml -tsvg -output render ./docs/src/images/plantuml/*.plantuml
+          mkdir -p ./docs/src/static/plantuml
+          mv ./docs/src/images/plantuml/render/* ./docs/src/static/plantuml/
+
+      - name: Render the projects roles and inventory diagrams
+        run: |
           distros=()
           for p in ./hosts/*/
           do

--- a/docs/src/contributing.rst
+++ b/docs/src/contributing.rst
@@ -134,3 +134,14 @@ WRONG:
 
     This feature adds a new role to implement
     an awesome new feature.
+
+
+Internal CI usage
+~~~~~~~~~~~~~~~~~
+
+The following diagram describes the internal usage of GitHub actions
+and GitLab to run the end-to-end jobs.
+
+    .. image:: static/plantuml/github_workflow.svg
+      :width: 100%
+      :alt: Sequence diagram of the CI GitHub workflow for the e2e jobs

--- a/docs/src/images/plantuml/github_workflow.plantuml
+++ b/docs/src/images/plantuml/github_workflow.plantuml
@@ -1,0 +1,31 @@
+@startuml
+actor RootUser
+control GitLab_Schedule
+
+RootUser [bold,#blue]-> GitHub_PR : Add CI label
+GitLab_Schedule [bold,#LightSeaGreen]-> GitLab_Schedule: Runs every 15 minutes
+GitLab_Schedule [bold,#green]-> GitHub_PR : Get labels from open PRs
+GitHub_PR [bold,#green]-> GitLab_Schedule: Send labels for open PRs
+
+Loop for each label
+  GitLab_Schedule [bold,#green]-> GitHub_PR : Remove label
+  GitLab_Schedule [bold,#green]-> GitHub_PR : Mark label as a "in progress job"
+  GitLab_Schedule [bold,#green]-> GitLab_Runner : Trigger job
+  GitLab_Runner [bold,#red]-> GitLab_Runner : Configure job parameters based in the label information
+  GitLab_Runner [bold,#purple]-> Worker_machines : Deploy the cluster
+  Worker_machines [bold,#purple]-> GitLab_Runner : Send the job result
+  GitLab_Runner [bold,#green]-> GitHub_PR : Write the job result in the PR
+  GitLab_Runner [bold,#green]-> GitHub_PR : Mark the job as finished (successfully or with failures)
+End
+
+GitHub_PR [bold,#blue]-> RootUser: Done
+
+legend
+    |= Color |= Type |= Description |
+    | <size:11><back:#Blue>           </back></size>|    <&arrow-right> | User action triggered by an elevated KubeInit member. |
+    | <size:11><back:#LightSeaGreen>           </back></size>|    <&arrow-right> | GitLab native scheduled job. |
+    | <size:11><back:#Green>           </back></size>|    <&arrow-right> | The ci/launch_e2e.py script located in the kubeinit repository.|
+    | <size:11><back:#Red>           </back></size>|    <&arrow-right> | The ci/run.sh script located in the kubeinit repository.|
+    | <size:11><back:#Purple>           </back></size>|    <&arrow-right> | Execution of the KubeInit's Ansible collection|
+endlegend
+@enduml


### PR DESCRIPTION
This commit adds information about
how the CI runs, and includes a
mechanism to autorender plantuml
diagrams directly.