### PR TITLE
docs: use always png on plantuml

### DIFF
--- a/.github/workflows/docs_build_pr.yml
+++ b/.github/workflows/docs_build_pr.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Render the plantuml diagrams
         run: |
-          plantuml -tsvg -output render ./docs/src/images/plantuml/*.plantuml
+          plantuml -tpng -output render ./docs/src/images/plantuml/*.plantuml
           mkdir -p ./docs/src/static/plantuml
           mv ./docs/src/images/plantuml/render/* ./docs/src/static/plantuml/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Render the plantuml diagrams
         run: |
-          plantuml -tsvg -output render ./docs/src/images/plantuml/*.plantuml
+          plantuml -tpng -output render ./docs/src/images/plantuml/*.plantuml
           mkdir -p ./docs/src/static/plantuml
           mv ./docs/src/images/plantuml/render/* ./docs/src/static/plantuml/
 

--- a/docs/src/contributing.rst
+++ b/docs/src/contributing.rst
@@ -142,6 +142,6 @@ Internal CI usage
 The following diagram describes the internal usage of GitHub actions
 and GitLab to run the end-to-end jobs.
 
-    .. image:: static/plantuml/github_workflow.svg
+    .. image:: static/plantuml/github_workflow.png
       :width: 100%
       :alt: Sequence diagram of the CI GitHub workflow for the e2e jobs

--- a/docs/src/static/css/custom.css
+++ b/docs/src/static/css/custom.css
@@ -1,3 +1,7 @@
 h3 {
     font-size: 90%;
 }
+
+.wy-nav-content {
+    max-width: none;
+}


### PR DESCRIPTION
PNG files always look better on
web, so let's use that extension by
default.