### PR TITLE
refactor: move tasks from post-deployment to deploy-cluster

### DIFF
--- a/kubeinit/roles/kubeinit_cdk/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/main.yml
@@ -43,17 +43,6 @@
     kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
   when: kubeinit_cluster_nodes_deployed is not defined or not kubeinit_cluster_nodes_deployed
 
-- name: Add cluster authorized keys in cluster nodes
-  ansible.posix.authorized_key:
-    user: root
-    key: "{{ authorized_key }}"
-    state: present
-  loop: "{{ (groups['all_cluster_nodes'] + groups['extra_nodes']) | product(kubeinit_cluster_hostvars.authorized_keys) }}"
-  vars:
-    cluster_node: "{{ item[0] }}"
-    authorized_key: "{{ item[1] }}"
-  delegate_to: "{{ cluster_node }}"
-
 - name: Render the cluster template
   ansible.builtin.template:
     src: "cloud.yml.j2"
@@ -213,6 +202,14 @@
   register: _result
   changed_when: "_result.rc == 0"
   delegate_to: "{{ kubeinit_provision_service_node }}"
+
+- name: Finished deploying cluster
+  ansible.builtin.shell: |
+    echo "Finished deploying CDK cluster"
+  args:
+    executable: /bin/bash
+  register: _result
+  changed_when: "_result.rc == 0"
 
 - name: Add task-deploy-cluster to tasks_completed
   ansible.builtin.add_host:

--- a/kubeinit/roles/kubeinit_cdk/tasks/post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/post_deployment_tasks.yml
@@ -14,6 +14,22 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Prepare services if needed
+  ansible.builtin.include_role:
+    name: kubeinit.kubeinit.kubeinit_services
+    tasks_from: prepare_services.yml
+    public: true
+  vars:
+    task_completed: "{{ hostvars['kubeinit-facts'] is defined }}"
+  when: not task_completed
+
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping before '{{ kubeinit_stop_before_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_before_task is defined and kubeinit_stop_before_task == 'task-post-deployment'
+
 #
 # Configure NFS
 #
@@ -27,10 +43,18 @@
     kubeinit_deployment_node_name: "{{ kubeinit_provision_service_node }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
 
-- name: "Finish"
-  ansible.builtin.shell: |
-    echo "Finished"
-  args:
-    executable: /bin/bash
-  register: _result
-  changed_when: "_result.rc == 0"
+- name: Add task-post-deployment to tasks_completed
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_cluster_facts_name }}"
+    tasks_completed: "{{ kubeinit_cluster_hostvars.tasks_completed | union(['task-post-deployment']) }}"
+
+- name: Update kubeinit_cluster_hostvars
+  ansible.builtin.set_fact:
+    kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
+
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping after '{{ kubeinit_stop_after_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task in kubeinit_cluster_hostvars.tasks_completed

--- a/kubeinit/roles/kubeinit_eks/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/main.yml
@@ -43,17 +43,6 @@
     kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
   when: kubeinit_cluster_nodes_deployed is not defined or not kubeinit_cluster_nodes_deployed
 
-- name: Add cluster authorized keys in cluster nodes
-  ansible.posix.authorized_key:
-    user: root
-    key: "{{ authorized_key }}"
-    state: present
-  loop: "{{ groups['all_cluster_nodes'] | product(kubeinit_cluster_hostvars.authorized_keys) }}"
-  vars:
-    cluster_node: "{{ item[0] }}"
-    authorized_key: "{{ item[1] }}"
-  delegate_to: "{{ cluster_node }}"
-
 - name: Copy cert to pki directory
   ansible.builtin.copy:
     content: "{{ kubeinit_cluster_hostvars.domain_cert }}"
@@ -244,6 +233,48 @@
   loop_control:
     loop_var: compute_node
   delegate_to: "{{ compute_node }}"
+
+- name: Fetch the kubeconfig from the first controller node
+  ansible.builtin.slurp:
+    src: ~/.kube/config
+  register: _result_cluster_kubeconfig
+  delegate_to: "{{ kubeinit_first_controller_node }}"
+
+- name: Create kube directory
+  ansible.builtin.file:
+    path: ~/.kube
+    state: directory
+    mode: '0644'
+  delegate_to: "{{ kubeinit_provision_service_node }}"
+
+- name: Store the kubeconfig to the provision services machine.
+  ansible.builtin.copy:
+    content: "{{ _result_cluster_kubeconfig.content | default('Empty file') | b64decode }}"
+    dest: ~/.kube/config
+    mode: '0644'
+  delegate_to: "{{ kubeinit_provision_service_node }}"
+
+- name: Label compute nodes
+  ansible.builtin.shell: |
+    kubectl label node {{ hostvars[item].fqdn }} node-role.kubernetes.io/worker=
+  args:
+    executable: /bin/bash
+  register: _result
+  changed_when: "_result.rc == 0"
+  loop: "{{ groups['all_compute_nodes'] }}"
+  delegate_to: "{{ kubeinit_provision_service_node }}"
+
+- name: Deploy EKS manifests.
+  ansible.builtin.shell: |
+    kubectl apply -f https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+    kubectl apply -f https://distro.eks.amazonaws.com/kubernetes-1-18/kubernetes-1-18-eks-1.yaml
+    kubectl get release kubernetes-1-18-eks-1
+    kubectl get release kubernetes-1-18-eks-1 -o yaml
+  args:
+    executable: /bin/bash
+  register: _result
+  changed_when: "_result.rc == 0"
+  delegate_to: "{{ kubeinit_provision_service_node }}"
 
 - name: Add task-deploy-cluster to tasks_completed
   ansible.builtin.add_host:

--- a/kubeinit/roles/kubeinit_eks/tasks/post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/post_deployment_tasks.yml
@@ -14,47 +14,21 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Fetch the kubeconfig from the first controller node
-  ansible.builtin.slurp:
-    src: ~/.kube/config
-  register: _result_cluster_kubeconfig
-  delegate_to: "{{ kubeinit_first_controller_node }}"
+- name: Prepare services if needed
+  ansible.builtin.include_role:
+    name: kubeinit.kubeinit.kubeinit_services
+    tasks_from: prepare_services.yml
+    public: true
+  vars:
+    task_completed: "{{ hostvars['kubeinit-facts'] is defined }}"
+  when: not task_completed
 
-- name: Create kube directory
-  ansible.builtin.file:
-    path: ~/.kube
-    state: directory
-    mode: '0644'
-  delegate_to: "{{ kubeinit_provision_service_node }}"
-
-- name: Store the kubeconfig to the provision services machine.
-  ansible.builtin.copy:
-    content: "{{ _result_cluster_kubeconfig.content | default('Empty file') | b64decode }}"
-    dest: ~/.kube/config
-    mode: '0644'
-  delegate_to: "{{ kubeinit_provision_service_node }}"
-
-- name: Label compute nodes
-  ansible.builtin.shell: |
-    kubectl label node {{ hostvars[item].fqdn }} node-role.kubernetes.io/worker=
-  args:
-    executable: /bin/bash
-  register: _result
-  changed_when: "_result.rc == 0"
-  loop: "{{ groups['all_compute_nodes'] }}"
-  delegate_to: "{{ kubeinit_provision_service_node }}"
-
-- name: Deploy EKS manifests.
-  ansible.builtin.shell: |
-    kubectl apply -f https://distro.eks.amazonaws.com/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
-    kubectl apply -f https://distro.eks.amazonaws.com/kubernetes-1-18/kubernetes-1-18-eks-1.yaml
-    kubectl get release kubernetes-1-18-eks-1
-    kubectl get release kubernetes-1-18-eks-1 -o yaml
-  args:
-    executable: /bin/bash
-  register: _result
-  changed_when: "_result.rc == 0"
-  delegate_to: "{{ kubeinit_provision_service_node }}"
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping before '{{ kubeinit_stop_before_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_before_task is defined and kubeinit_stop_before_task == 'task-post-deployment'
 
 #
 # Configure NFS
@@ -68,3 +42,19 @@
   vars:
     kubeinit_deployment_node_name: "{{ kubeinit_provision_service_node }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
+
+- name: Add task-post-deployment to tasks_completed
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_cluster_facts_name }}"
+    tasks_completed: "{{ kubeinit_cluster_hostvars.tasks_completed | union(['task-post-deployment']) }}"
+
+- name: Update kubeinit_cluster_hostvars
+  ansible.builtin.set_fact:
+    kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
+
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping after '{{ kubeinit_stop_after_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task in kubeinit_cluster_hostvars.tasks_completed

--- a/kubeinit/roles/kubeinit_k8s/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/main.yml
@@ -181,6 +181,27 @@
     loop_var: compute_node
   delegate_to: "{{ kubeinit_first_controller_node }}"
 
+# We fetch the kubeconfig from the first controller node
+- name: Copying the kubeconfig to a variable
+  ansible.builtin.slurp:
+    src: ~/.kube/config
+  register: _result_cluster_kubeconfig
+  delegate_to: "{{ kubeinit_first_controller_node }}"
+
+- name: Create kube directory
+  ansible.builtin.file:
+    path: ~/.kube
+    state: directory
+    mode: '0644'
+  delegate_to: "{{ kubeinit_provision_service_node }}"
+
+- name: Storing the master kubeconfig to the services machine.
+  ansible.builtin.copy:
+    content: "{{ _result_cluster_kubeconfig.content | default('Empty file') | b64decode }}"
+    dest: ~/.kube/config
+    mode: '0644'
+  delegate_to: "{{ kubeinit_provision_service_node }}"
+
 - name: Add task-deploy-cluster to tasks_completed
   ansible.builtin.add_host:
     name: "{{ kubeinit_cluster_facts_name }}"

--- a/kubeinit/roles/kubeinit_k8s/tasks/post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/post_deployment_tasks.yml
@@ -14,26 +14,21 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-# We fetch the kubeconfig from the first controller node
-- name: Copying the kubeconfig to a variable
-  ansible.builtin.slurp:
-    src: ~/.kube/config
-  register: _result_cluster_kubeconfig
-  delegate_to: "{{ kubeinit_first_controller_node }}"
+- name: Prepare services if needed
+  ansible.builtin.include_role:
+    name: kubeinit.kubeinit.kubeinit_services
+    tasks_from: prepare_services.yml
+    public: true
+  vars:
+    task_completed: "{{ hostvars['kubeinit-facts'] is defined }}"
+  when: not task_completed
 
-- name: Create kube directory
-  ansible.builtin.file:
-    path: ~/.kube
-    state: directory
-    mode: '0644'
-  delegate_to: "{{ kubeinit_provision_service_node }}"
-
-- name: Storing the master kubeconfig to the services machine.
-  ansible.builtin.copy:
-    content: "{{ _result_cluster_kubeconfig.content | default('Empty file') | b64decode }}"
-    dest: ~/.kube/config
-    mode: '0644'
-  delegate_to: "{{ kubeinit_provision_service_node }}"
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping before '{{ kubeinit_stop_before_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_before_task is defined and kubeinit_stop_before_task == 'task-post-deployment'
 
 #
 # Configure NFS
@@ -47,3 +42,19 @@
   vars:
     kubeinit_deployment_node_name: "{{ kubeinit_provision_service_node }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
+
+- name: Add task-post-deployment to tasks_completed
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_cluster_facts_name }}"
+    tasks_completed: "{{ kubeinit_cluster_hostvars.tasks_completed | union(['task-post-deployment']) }}"
+
+- name: Update kubeinit_cluster_hostvars
+  ansible.builtin.set_fact:
+    kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
+
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping after '{{ kubeinit_stop_after_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task in kubeinit_cluster_hostvars.tasks_completed

--- a/kubeinit/roles/kubeinit_kid/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_kid/tasks/main.yml
@@ -43,17 +43,6 @@
     kubeinit_deployment_delegate: "{{ hostvars[cluster_node].target }}"
   when: kubeinit_cluster_nodes_deployed is not defined or not kubeinit_cluster_nodes_deployed
 
-- name: Add cluster authorized keys in all cluster nodes
-  ansible.posix.authorized_key:
-    user: root
-    key: "{{ authorized_key }}"
-    state: present
-  loop: "{{ groups['all_cluster_nodes'] | product(kubeinit_cluster_hostvars.authorized_keys) }}"
-  vars:
-    cluster_node: "{{ item[0] }}"
-    authorized_key: "{{ item[1] }}"
-  delegate_to: "{{ cluster_node }}"
-
 - name: Install controller requirements
   ansible.builtin.package:
     name: "{{ kubeinit_kid_controller_dependencies }}"
@@ -80,6 +69,15 @@
     path: ~/.kube
     state: directory
     mode: '0644'
+  delegate_to: "{{ kubeinit_provision_service_node }}"
+
+- name: Touch a file
+  ansible.builtin.shell: |
+    touch ~/.kube/config
+  args:
+    executable: /bin/bash
+  register: _result
+  changed_when: "_result.rc == 0"
   delegate_to: "{{ kubeinit_provision_service_node }}"
 
 - name: Add task-deploy-cluster to tasks_completed

--- a/kubeinit/roles/kubeinit_kid/tasks/post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_kid/tasks/post_deployment_tasks.yml
@@ -14,6 +14,22 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Prepare services if needed
+  ansible.builtin.include_role:
+    name: kubeinit.kubeinit.kubeinit_services
+    tasks_from: prepare_services.yml
+    public: true
+  vars:
+    task_completed: "{{ hostvars['kubeinit-facts'] is defined }}"
+  when: not task_completed
+
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping before '{{ kubeinit_stop_before_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_before_task is defined and kubeinit_stop_before_task == 'task-post-deployment'
+
 #
 # Configure NFS
 #
@@ -27,11 +43,18 @@
     kubeinit_deployment_node_name: "{{ kubeinit_provision_service_node }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
 
-- name: Touch a file
-  ansible.builtin.shell: |
-    touch ~/.kube/config
-  args:
-    executable: /bin/bash
-  register: _result
-  changed_when: "_result.rc == 0"
-  delegate_to: "{{ kubeinit_provision_service_node }}"
+- name: Add task-post-deployment to tasks_completed
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_cluster_facts_name }}"
+    tasks_completed: "{{ kubeinit_cluster_hostvars.tasks_completed | union(['task-post-deployment']) }}"
+
+- name: Update kubeinit_cluster_hostvars
+  ansible.builtin.set_fact:
+    kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
+
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping after '{{ kubeinit_stop_after_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task in kubeinit_cluster_hostvars.tasks_completed

--- a/kubeinit/roles/kubeinit_nfs/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_nfs/tasks/main.yml
@@ -20,7 +20,7 @@
     name: "{{ kubeinit_nfs_packages }}"
     state: present
 
-- name: "configure NFS shares of CentOS based guests"
+- name: "Configure NFS shares of CentOS based guests"
   ansible.builtin.shell: |
     set -o pipefail
     systemctl enable nfs-server rpcbind
@@ -37,7 +37,7 @@
   changed_when: "_result.rc == 0"
   when: hostvars[kubeinit_deployment_node_name].os == 'centos'
 
-- name: "configure NFS shares of Ubuntu based guests"
+- name: "Configure NFS shares of Ubuntu based guests"
   ansible.builtin.shell: |
     set -o pipefail
     mkdir -p /var/nfsshare
@@ -53,7 +53,7 @@
   when: hostvars[kubeinit_deployment_node_name].os == 'ubuntu' or hostvars[kubeinit_deployment_node_name].os == 'debian'
 
 #
-# add nfs dynamic provisioning
+# Add nfs dynamic provisioning
 #
 
 - name: Add nfs provisioning role
@@ -193,95 +193,3 @@
   changed_when: "_result.rc == 0"
   args:
     executable: /bin/bash
-
-- name: Tasks only needed for Openshift
-  block:
-
-    - name: Add security context constraint for nfs provisioner
-      ansible.builtin.shell: |
-        cat << EOF > ~/nfs_scc.yaml
-        apiVersion: security.openshift.io/v1
-        kind: SecurityContextConstraints
-        metadata:
-          name: nfs-provisioner
-        allowHostDirVolumePlugin: true
-        allowHostIPC: false
-        allowHostNetwork: false
-        allowHostPID: false
-        allowHostPorts: false
-        allowPrivilegedContainer: false
-        allowedCapabilities:
-        - DAC_READ_SEARCH
-        - SYS_RESOURCE
-        defaultAddCapabilities: null
-        fsGroup:
-          type: MustRunAs
-        priority: null
-        readOnlyRootFilesystem: false
-        requiredDropCapabilities:
-        - KILL
-        - MKNOD
-        - SYS_CHROOT
-        runAsUser:
-          type: RunAsAny
-        seLinuxContext:
-          type: MustRunAs
-        supplementalGroups:
-          type: RunAsAny
-        volumes:
-        - configMap
-        - downwardAPI
-        - emptyDir
-        - hostPath
-        - nfs
-        - persistentVolumeClaim
-        - secret
-        EOF
-        export KUBECONFIG=~/.kube/config
-        kubectl apply -f ~/nfs_scc.yaml --request-timeout=1800s
-      register: _result
-      changed_when: "_result.rc == 0"
-      args:
-        executable: /bin/bash
-
-    - name: Apply nfs security policy to nfs user
-      ansible.builtin.shell: |
-        export KUBECONFIG=~/.kube/config
-        oc adm policy add-scc-to-user nfs-provisioner -z nfs-client-provisioner
-      register: _result
-      changed_when: "_result.rc == 0"
-      args:
-        executable: /bin/bash
-
-    - name: Wait for the image registry operator to start its components
-      ansible.builtin.shell: |
-        export KUBECONFIG=~/.kube/config
-        oc get configs.imageregistry.operator.openshift.io cluster
-      register: _result
-      retries: 60
-      delay: 20
-      until: _result.rc == 0
-      changed_when: "_result.rc == 0"
-      args:
-        executable: /bin/bash
-
-    - name: Patch imageregistry operator to claim storage
-      ansible.builtin.shell: |
-        # We patch the imageregistry operator to create a claim that managed-nfs-storage will satisfy
-        export KUBECONFIG=~/.kube/config
-        oc patch --request-timeout=1800s configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec": {"storage": {"pvc": {"claim": "" }}}}'
-      register: _result
-      changed_when: "_result.rc == 0"
-      args:
-        executable: /bin/bash
-
-    - name: Patch imageregistry operator to move to Managed state
-      ansible.builtin.shell: |
-        export KUBECONFIG=~/.kube/config
-        oc patch --request-timeout=1800s configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec": {"managementState": "Managed" }}'
-      register: _result
-      changed_when: "_result.rc == 0"
-      args:
-        executable: /bin/bash
-
-  when: kubeinit_inventory_cluster_distro == 'okd'

--- a/kubeinit/roles/kubeinit_okd/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/main.yml
@@ -172,6 +172,74 @@
     kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
     kubeinit_ignition_name: worker
 
+- name: Complete the cluster deployment on the provision service node
+  block:
+
+    - name: "verify that all the csr are loaded and aproved for the deployed nodes"
+      ansible.builtin.shell: |
+        set -o pipefail
+        export KUBECONFIG=~/install_dir/auth/kubeconfig; \
+        oc get csr -ojson | jq -r '.items[] | .metadata.name' | xargs oc adm certificate approve >/dev/null 2>&1; \
+        oc get csr | grep Approved
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+      retries: 60
+      delay: 60
+      # Per each node we have 2 certs one per kubelet-serving and another per kube-apiserver-client-kubelet
+      until: _result.stdout_lines | default([]) | list | count == ( groups['all_controller_nodes'] | count + groups['all_compute_nodes'] | count ) * 2
+
+    - name: "wait until all nodes are ready"
+      ansible.builtin.shell: |
+        set -o pipefail
+        export KUBECONFIG=~/install_dir/auth/kubeconfig; \
+        oc get nodes | grep " Ready"
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+      retries: 60
+      delay: 60
+      until: _result.stdout_lines | default([]) | list | count == ( (groups['all_controller_nodes'] | count) + (groups['all_compute_nodes'] | count) )
+
+    - name: Copy the kubeconfig
+      ansible.builtin.shell: |
+        cp ~/install_dir/auth/kubeconfig ~/.kube/config
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Get some final cluster information
+      ansible.builtin.shell: |
+        set -eo pipefail
+        export KUBECONFIG=~/install_dir/auth/kubeconfig
+        oc get nodes
+      args:
+        executable: /bin/bash
+      ignore_errors: yes
+      register: _result_cluster_info
+      changed_when: "_result_cluster_info.rc == 0"
+
+    - name: Display final debug info
+      ansible.builtin.debug:
+        var: _result_cluster_info
+
+    - name: Print some final data
+      vars:
+        msg: |
+          Get the kubeadmin password from the services machine
+            cat ~/install_dir/auth/kubeadmin-password
+          The OpenShift UI endpoint is:
+            console-openshift-console.apps.{{ kubeinit_cluster_fqdn }}
+      ansible.builtin.debug:
+        msg: "{{ msg.split('\n') }}"
+
+  vars:
+    kubeinit_deployment_node_name: "{{ kubeinit_provision_service_node }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+
 - name: Add task-deploy-cluster to tasks_completed
   ansible.builtin.add_host:
     name: "{{ kubeinit_cluster_facts_name }}"

--- a/kubeinit/roles/kubeinit_okd/tasks/post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/post_deployment_tasks.yml
@@ -14,89 +14,155 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Configure the post deployment tasks on the provision service node
+- name: Prepare services if needed
+  ansible.builtin.include_role:
+    name: kubeinit.kubeinit.kubeinit_services
+    tasks_from: prepare_services.yml
+    public: true
+  vars:
+    task_completed: "{{ hostvars['kubeinit-facts'] is defined }}"
+  when: not task_completed
+
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping before '{{ kubeinit_stop_before_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_before_task is defined and kubeinit_stop_before_task == 'task-post-deployment'
+
+#
+# Configure NFS
+#
+- name: Delegate to provision service node
   block:
 
-    - name: "verify that all the csr are loaded and aproved for the deployed nodes"
-      ansible.builtin.shell: |
-        set -o pipefail
-        export KUBECONFIG=~/install_dir/auth/kubeconfig; \
-        oc get csr -ojson | jq -r '.items[] | .metadata.name' | xargs oc adm certificate approve >/dev/null 2>&1; \
-        oc get csr | grep Approved
-      args:
-        executable: /bin/bash
-      register: _result
-      changed_when: "_result.rc == 0"
-      retries: 60
-      delay: 60
-      # Per each node we have 2 certs one per kubelet-serving and another per kube-apiserver-client-kubelet
-      until: _result.stdout_lines | default([]) | list | count == ( groups['all_controller_nodes'] | count + groups['all_compute_nodes'] | count ) * 2
-
-    - name: "wait until all nodes are ready"
-      ansible.builtin.shell: |
-        set -o pipefail
-        export KUBECONFIG=~/install_dir/auth/kubeconfig; \
-        oc get nodes | grep " Ready"
-      args:
-        executable: /bin/bash
-      register: _result
-      changed_when: "_result.rc == 0"
-      retries: 60
-      delay: 60
-      until: _result.stdout_lines | default([]) | list | count == ( (groups['all_controller_nodes'] | count) + (groups['all_compute_nodes'] | count) )
-
-    - name: Copy the kubeconfig
-      ansible.builtin.shell: |
-        cp ~/install_dir/auth/kubeconfig ~/.kube/config
-      args:
-        executable: /bin/bash
-      register: _result
-      changed_when: "_result.rc == 0"
-
-    #
-    # Configure NFS
-    #
     - name: Configure NFS
       ansible.builtin.include_role:
         name: kubeinit.kubeinit.kubeinit_nfs
         public: true
       when: "'nfs' in kubeinit_cluster_hostvars.services"
 
-    #
-    # Deploy KubeVirt
-    #
+    - name: Add security context constraint for nfs provisioner
+      ansible.builtin.shell: |
+        cat << EOF > ~/nfs_scc.yaml
+        apiVersion: security.openshift.io/v1
+        kind: SecurityContextConstraints
+        metadata:
+          name: nfs-provisioner
+        allowHostDirVolumePlugin: true
+        allowHostIPC: false
+        allowHostNetwork: false
+        allowHostPID: false
+        allowHostPorts: false
+        allowPrivilegedContainer: false
+        allowedCapabilities:
+        - DAC_READ_SEARCH
+        - SYS_RESOURCE
+        defaultAddCapabilities: null
+        fsGroup:
+          type: MustRunAs
+        priority: null
+        readOnlyRootFilesystem: false
+        requiredDropCapabilities:
+        - KILL
+        - MKNOD
+        - SYS_CHROOT
+        runAsUser:
+          type: RunAsAny
+        seLinuxContext:
+          type: MustRunAs
+        supplementalGroups:
+          type: RunAsAny
+        volumes:
+        - configMap
+        - downwardAPI
+        - emptyDir
+        - hostPath
+        - nfs
+        - persistentVolumeClaim
+        - secret
+        EOF
+        export KUBECONFIG=~/.kube/config
+        kubectl apply -f ~/nfs_scc.yaml --request-timeout=1800s
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+      when: "'nfs' in kubeinit_cluster_hostvars.services"
+
+    - name: Apply nfs security policy to nfs user
+      ansible.builtin.shell: |
+        export KUBECONFIG=~/.kube/config
+        oc adm policy add-scc-to-user nfs-provisioner -z nfs-client-provisioner
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+      when: "'nfs' in kubeinit_cluster_hostvars.services"
+
+    - name: Wait for the image registry operator to start its components
+      ansible.builtin.shell: |
+        export KUBECONFIG=~/.kube/config
+        oc get configs.imageregistry.operator.openshift.io cluster
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+      retries: 60
+      delay: 20
+      until: _result.rc == 0
+      when: "'nfs' in kubeinit_cluster_hostvars.services"
+
+    - name: Patch imageregistry operator to claim storage
+      ansible.builtin.shell: |
+        # We patch the imageregistry operator to create a claim that managed-nfs-storage will satisfy
+        export KUBECONFIG=~/.kube/config
+        oc patch --request-timeout=1800s configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec": {"storage": {"pvc": {"claim": "" }}}}'
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+      when: "'nfs' in kubeinit_cluster_hostvars.services"
+
+    - name: Patch imageregistry operator to move to Managed state
+      ansible.builtin.shell: |
+        export KUBECONFIG=~/.kube/config
+        oc patch --request-timeout=1800s configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec": {"managementState": "Managed" }}'
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+      when: "'nfs' in kubeinit_cluster_hostvars.services"
+
+  vars:
+    kubeinit_deployment_node_name: "{{ kubeinit_provision_service_node }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+
+#
+# Deploy KubeVirt
+#
+- block:
     - name: Deploy KubeVirt
       ansible.builtin.include_role:
         name: kubeinit.kubeinit.kubeinit_kubevirt
         public: yes
       when: not kubeinit_okd_openshift_deploy | default(False)
-
-    - name: Get some final cluster information
-      ansible.builtin.shell: |
-        set -eo pipefail
-        echo "show stat" | socat unix-connect:/var/lib/haproxy/stats stdio
-        export KUBECONFIG=~/install_dir/auth/kubeconfig
-        oc get nodes
-      args:
-        executable: /bin/bash
-      ignore_errors: yes
-      register: _result_cluster_info
-      changed_when: "_result_cluster_info.rc == 0"
-
-    - name: Display final debug info
-      ansible.builtin.debug:
-        var: _result_cluster_info
-
-    - name: Print some final data
-      vars:
-        msg: |
-          Get the kubeadmin password from the services machine
-            cat ~/install_dir/auth/kubeadmin-password
-          The OpenShift UI endpoint is:
-            console-openshift-console.apps.{{ kubeinit_cluster_fqdn }}
-      ansible.builtin.debug:
-        msg: "{{ msg.split('\n') }}"
-
   vars:
     kubeinit_deployment_node_name: "{{ kubeinit_provision_service_node }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
+
+- name: Add task-post-deployment to tasks_completed
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_cluster_facts_name }}"
+    tasks_completed: "{{ kubeinit_cluster_hostvars.tasks_completed | union(['task-post-deployment']) }}"
+
+- name: Update kubeinit_cluster_hostvars
+  ansible.builtin.set_fact:
+    kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
+
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping after '{{ kubeinit_stop_after_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task in kubeinit_cluster_hostvars.tasks_completed

--- a/kubeinit/roles/kubeinit_prepare/tasks/gather_host_facts.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/gather_host_facts.yml
@@ -150,7 +150,7 @@
     - name: Add ansible facts to hostvars
       ansible.builtin.add_host:
         name: "{{ kubeinit_deployment_node_name }}"
-        ansible_default_ipv4_address: "{{ _result_facts.ansible_facts.ansible_default_ipv4.address }}"
+        ansible_default_ipv4_address: "{{ _result_facts.ansible_facts.ansible_default_ipv4.address | default(omit) }}"
         ansible_hostname: "{{ _result_facts.ansible_facts.ansible_hostname }}"
         ansible_distribution: "{{ _result_facts.ansible_facts.ansible_distribution }}"
         ansible_distribution_major_version: "{{ _result_facts.ansible_facts.ansible_distribution_major_version }}"

--- a/kubeinit/roles/kubeinit_rke/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/main.yml
@@ -43,17 +43,6 @@
     kubeinit_deployment_delegate: "{{ hostvars[cluster_node].target }}"
   when: kubeinit_cluster_nodes_deployed is not defined or not kubeinit_cluster_nodes_deployed
 
-- name: Add cluster authorized keys in cluster nodes
-  ansible.posix.authorized_key:
-    user: root
-    key: "{{ authorized_key }}"
-    state: present
-  loop: "{{ groups['all_cluster_nodes'] | product(kubeinit_cluster_hostvars.authorized_keys) }}"
-  vars:
-    cluster_node: "{{ item[0] }}"
-    authorized_key: "{{ item[1] }}"
-  delegate_to: "{{ cluster_node }}"
-
 - name: Enable insecure registry in Docker
   ansible.builtin.shell: |
     # This is mandatory so the cluster nodes can fetch the
@@ -103,6 +92,13 @@
     cp ~/kube_config_cluster.yml ~/.kube/config
   args:
     executable: /bin/bash
+  register: _result
+  changed_when: "_result.rc == 0"
+  delegate_to: "{{ kubeinit_provision_service_node }}"
+
+- name: Touch a file
+  ansible.builtin.command: |
+    touch ~/.kube/config
   register: _result
   changed_when: "_result.rc == 0"
   delegate_to: "{{ kubeinit_provision_service_node }}"

--- a/kubeinit/roles/kubeinit_rke/tasks/post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/post_deployment_tasks.yml
@@ -14,6 +14,22 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Prepare services if needed
+  ansible.builtin.include_role:
+    name: kubeinit.kubeinit.kubeinit_services
+    tasks_from: prepare_services.yml
+    public: true
+  vars:
+    task_completed: "{{ hostvars['kubeinit-facts'] is defined }}"
+  when: not task_completed
+
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping before '{{ kubeinit_stop_before_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_before_task is defined and kubeinit_stop_before_task == 'task-post-deployment'
+
 #
 # Configure NFS
 #
@@ -27,9 +43,18 @@
     kubeinit_deployment_node_name: "{{ kubeinit_provision_service_node }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
 
-- name: Touch a file
-  ansible.builtin.command: |
-    touch ~/.kube/config
-  register: _result
-  changed_when: "_result.rc == 0"
-  delegate_to: "{{ kubeinit_provision_service_node }}"
+- name: Add task-post-deployment to tasks_completed
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_cluster_facts_name }}"
+    tasks_completed: "{{ kubeinit_cluster_hostvars.tasks_completed | union(['task-post-deployment']) }}"
+
+- name: Update kubeinit_cluster_hostvars
+  ansible.builtin.set_fact:
+    kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
+
+- block:
+    - name: Check to see if we should stop here
+      ansible.builtin.debug: msg="Stopping after '{{ kubeinit_stop_after_task }}'"
+    - name: End play
+      ansible.builtin.meta: end_play
+  when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task in kubeinit_cluster_hostvars.tasks_completed


### PR DESCRIPTION
also cleanup redundant authorized_key distribution as it is already part of creating the guest vm