### PR TITLE
fix: remove virt-top from Debian 11 and add testing repos

### DIFF
--- a/kubeinit/galaxy.yml
+++ b/kubeinit/galaxy.yml
@@ -30,6 +30,7 @@ dependencies:
   community.general: '==3.2.0'
   community.libvirt: '==1.0.1'
   containers.podman: '==1.6.1'
+  openvswitch.openvswitch: '==2.0.2'
 repository: 'https://github.com/kubeinit/kubeinit'
 homepage: 'https://www.kubeinit.org'
 issues: 'https://github.com/kubeinit/kubeinit/issues'

--- a/kubeinit/requirements.yml
+++ b/kubeinit/requirements.yml
@@ -16,3 +16,5 @@ collections:
     version: '1.0.1'
   - name: containers.podman
     version: '1.6.1'
+  - name: openvswitch.openvswitch
+    version: '2.0.2'

--- a/kubeinit/roles/kubeinit_cdk/tasks/post_configure_guest.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/post_configure_guest.yml
@@ -14,6 +14,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+- name: Add the Podman Ubuntu package repository to Apt
+  ansible.builtin.shell: |
+    set -eo pipefail
+    version_id=$(sed -n -e 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)
+    echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${version_id}/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+    curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${version_id}/Release.key" | apt-key add -
+    apt-get update
+  args:
+    executable: /bin/bash
+  register: _result
+  changed_when: "_result.rc == 0"
+
 - name: Prepare podman
   ansible.builtin.include_role:
     name: kubeinit.kubeinit.kubeinit_prepare

--- a/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
@@ -108,7 +108,6 @@ kubeinit_libvirt_hypervisor_dependencies:
     - libvirt-daemon-system
     - libvirt-daemon
     - virt-manager
-    - virt-top
     - bridge-utils
     - libguestfs-tools
     - genisoimage

--- a/kubeinit/roles/kubeinit_libvirt/tasks/cleanup_libvirt.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/cleanup_libvirt.yml
@@ -17,19 +17,108 @@
 #
 # Cleanup OVN network
 #
-- name: Clean OVN/OVS resources
-  ansible.builtin.shell: |
-    set -o pipefail
-    ip route del {{ kubeinit_cluster_network }} via 172.16.0.1 dev br-ex || true
-    /usr/bin/ovn-nbctl --if-exists ls-del sw0 || true
-    /usr/bin/ovn-nbctl --if-exists lr-del lr0 || true
-    /usr/bin/ovn-nbctl --if-exists ls-del public || true
-    /usr/bin/ovs-vsctl --if-exists del-br br-int || true
-    /usr/bin/ovs-vsctl --if-exists del-br br-ex || true
-    ip link del genev_sys_6081 || true
-    ovs-dpctl del-dp ovs-system || true
-  args:
-    executable: /bin/bash
+
+- name: Clean OVN/OVS resources (route)
+  ansible.builtin.command: ip route del {{ kubeinit_cluster_network }} via 172.16.0.1 dev br-ex
+  ignore_errors: true
+  register: _result
+  changed_when: "_result.rc == 0"
+  loop: "{{ groups['all_hosts'] }}"
+  loop_control:
+    loop_var: cluster_role_item
+  vars:
+    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: >
+    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+
+- name: Clean OVN/OVS resources (sw0)
+  ansible.builtin.command: /usr/bin/ovn-nbctl --if-exists ls-del sw0
+  ignore_errors: true
+  register: _result
+  changed_when: "_result.rc == 0"
+  loop: "{{ groups['all_hosts'] }}"
+  loop_control:
+    loop_var: cluster_role_item
+  vars:
+    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: >
+    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+
+- name: Clean OVN/OVS resources (lr0)
+  ansible.builtin.command: /usr/bin/ovn-nbctl --if-exists lr-del lr0
+  ignore_errors: true
+  register: _result
+  changed_when: "_result.rc == 0"
+  loop: "{{ groups['all_hosts'] }}"
+  loop_control:
+    loop_var: cluster_role_item
+  vars:
+    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: >
+    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+
+- name: Clean OVN/OVS resources (public)
+  ansible.builtin.command: /usr/bin/ovn-nbctl --if-exists ls-del public
+  ignore_errors: true
+  register: _result
+  changed_when: "_result.rc == 0"
+  loop: "{{ groups['all_hosts'] }}"
+  loop_control:
+    loop_var: cluster_role_item
+  vars:
+    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: >
+    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+
+- name: Clean OVN/OVS resources (br-int)
+  openvswitch.openvswitch.openvswitch_bridge:
+    bridge: br-int
+    state: absent
+  ignore_errors: true
+  loop: "{{ groups['all_hosts'] }}"
+  loop_control:
+    loop_var: cluster_role_item
+  vars:
+    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: >
+    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+
+- name: Clean OVN/OVS resources (br-ex)
+  openvswitch.openvswitch.openvswitch_bridge:
+    bridge: br-ex
+    state: absent
+  ignore_errors: true
+  loop: "{{ groups['all_hosts'] }}"
+  loop_control:
+    loop_var: cluster_role_item
+  vars:
+    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: >
+    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+
+- name: Clean OVN/OVS resources (genev_sys_6081)
+  ansible.builtin.command: ip link del genev_sys_6081
+  ignore_errors: true
+  register: _result
+  changed_when: "_result.rc == 0"
+  loop: "{{ groups['all_hosts'] }}"
+  loop_control:
+    loop_var: cluster_role_item
+  vars:
+    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: >
+    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+
+- name: Clean OVN/OVS resources (ovs-system)
+  ansible.builtin.command: ovs-dpctl del-dp ovs-system
+  ignore_errors: true
   register: _result
   changed_when: "_result.rc == 0"
   loop: "{{ groups['all_hosts'] }}"

--- a/kubeinit/roles/kubeinit_libvirt/tasks/create_network.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/create_network.yml
@@ -39,7 +39,7 @@
 #
 # We install all OVN requirements in the ovn-central host
 #
-- name: Install OVN packages in CentOS/RHEL
+- name: Install OVN central packages in CentOS/RHEL
   ansible.builtin.shell: |
     dnf install -y centos-release-nfv-openvswitch
     dnf install -y openvswitch2.13 \
@@ -53,7 +53,7 @@
   delegate_to: "{{ kubeinit_ovn_central_host }}"
   when: hostvars[kubeinit_ovn_central_host].distribution_family == 'CentOS'
 
-- name: Install OVN packages in Fedora
+- name: Install OVN central packages in Fedora
   ansible.builtin.command: |
     dnf install -y openvswitch \
                    ovn \
@@ -64,7 +64,7 @@
   delegate_to: "{{ kubeinit_ovn_central_host }}"
   when: hostvars[kubeinit_ovn_central_host].distribution_family == 'Fedora'
 
-- name: Install OVN packages in Ubuntu/Debian
+- name: Install OVN central packages in Ubuntu/Debian
   ansible.builtin.command: |
     apt-get install -y openvswitch-common \
                        openvswitch-switch \
@@ -87,7 +87,7 @@
     loop_var: ovn_host
   when: ovn_host not in kubeinit_ovn_central_host
 
-- name: Install OVN packages in CentOS/RHEL
+- name: Install OVN host packages in CentOS/RHEL
   ansible.builtin.shell: |
     dnf install -y centos-release-nfv-openvswitch
     dnf install -y openvswitch2.13 \
@@ -103,7 +103,7 @@
   delegate_to: "{{ ovn_host }}"
   when: hostvars[ovn_host].distribution_family == 'CentOS'
 
-- name: Install OVN packages in Fedora
+- name: Install OVN host packages in Fedora
   ansible.builtin.command: |
     dnf install -y openvswitch \
                    ovn \
@@ -116,7 +116,7 @@
   delegate_to: "{{ ovn_host }}"
   when: hostvars[ovn_host].distribution_family == 'Fedora'
 
-- name: Install OVN packages in Ubuntu/Debian
+- name: Install OVN host packages in Ubuntu/Debian
   ansible.builtin.command: |
     apt-get install -y openvswitch-common \
                        openvswitch-switch \

--- a/kubeinit/roles/kubeinit_libvirt/tasks/deploy_debian_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/deploy_debian_guest.yml
@@ -178,18 +178,6 @@
       register: _result
       changed_when: "_result.rc == 0"
 
-    - name: Add the Podman debian package repository to Apt
-      ansible.builtin.shell: |
-        set -eo pipefail
-        version_id=$(sed -n -e 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)
-        echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${version_id}/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-        curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${version_id}/Release.key" | apt-key add -
-        apt-get update
-      args:
-        executable: /bin/bash
-      register: _result
-      changed_when: "_result.rc == 0"
-
     - name: Update packages
       ansible.builtin.package:
         name: "*"

--- a/kubeinit/roles/kubeinit_libvirt/tasks/deploy_ubuntu_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/deploy_ubuntu_guest.yml
@@ -117,18 +117,6 @@
 - name: Configure common requirements in Ubuntu guests
   block:
 
-    - name: Add the Podman ubuntu package repository to Apt
-      ansible.builtin.shell: |
-        set -eo pipefail
-        version_id=$(sed -n -e 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)
-        echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${version_id}/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-        curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${version_id}/Release.key" | apt-key add -
-        apt-get update
-      args:
-        executable: /bin/bash
-      register: _result
-      changed_when: "_result.rc == 0"
-
     - name: Add kubernetes repo for latest kubectl (Ubuntu)
       ansible.builtin.shell: |
         set -eo pipefail

--- a/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/main.yml
@@ -56,6 +56,25 @@
   when: hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS' or hostvars[kubeinit_deployment_node_name].distribution_family == 'Fedora'
   register: _result_installed_packages_centos
 
+#
+# BEGIN:TODO:FIXME: Remove this testing repo after OVN is in the stable branch.
+# This should be applicable only to Debian and not to Ubuntu
+#
+- name: Enable the testing repo in Debian
+  ansible.builtin.lineinfile:
+    state: present
+    path: "/etc/apt/sources.list"
+    line: "deb http://http.us.debian.org/debian/ testing non-free contrib main"
+  when: hostvars[kubeinit_deployment_node_name].os == 'debian'
+
+- name: Update packages list
+  ansible.builtin.command: apt-get update
+  when: hostvars[kubeinit_deployment_node_name].os == 'debian'
+
+#
+# END:TODO:FIXME
+#
+
 - name: Install Debian based requirements
   ansible.builtin.package:
     name: "{{ kubeinit_libvirt_hypervisor_dependencies.debian }}"

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_podman.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_podman.yml
@@ -14,32 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Install podman if it is not already installed
-  block:
-
-    - name: Add kubic repo for latest podman (Debian)
-      ansible.builtin.shell: |
-        set -eo pipefail
-        version_id=$(sed -n -e 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)
-        echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${version_id}/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-        curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_${version_id}/Release.key" | apt-key add -
-        apt-get update
-      args:
-        executable: /bin/bash
-      when: hostvars[kubeinit_deployment_delegate].os == 'debian'
-
-    - name: Add kubic repo for latest podman (Ubuntu)
-      ansible.builtin.shell: |
-        set -eo pipefail
-        version_id=$(sed -n -e 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)
-        echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${version_id}/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-        curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${version_id}/Release.key" | apt-key add -
-        apt-get update
-      args:
-        executable: /bin/bash
-      when: hostvars[kubeinit_deployment_delegate].os == 'ubuntu'
-
-  when: not hostvars[kubeinit_deployment_delegate].podman_is_installed
+#
+# We should already have podman in all the distros we use.
+#
 
 - name: Install common requirements
   ansible.builtin.package:

--- a/kubeinit/roles/kubeinit_rke/tasks/prepare_cluster.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/prepare_cluster.yml
@@ -27,18 +27,6 @@
 - name: Configure the provision service node
   block:
 
-    - name: Add kubic repo for latest podman (Ubuntu)
-      ansible.builtin.shell: |
-        set -eo pipefail
-        version_id=$(sed -n -e 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)
-        echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${version_id}/ /" > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-        curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${version_id}/Release.key" | apt-key add -
-        apt-get update
-      args:
-        executable: /bin/bash
-      register: _result
-      changed_when: "_result.rc == 0"
-
     - name: Add kubernetes repo for latest kubectl (Ubuntu)
       ansible.builtin.shell: |
         set -eo pipefail


### PR DESCRIPTION
In Debian 11 is not yet published the list of OVN
packages to deploy the cluster.
This commit removes virt-top as is not available anymore,
and enables the testing repos.