### PR TITLE
refactor: support multiple clusters per inventory

### DIFF
--- a/kubeinit/inventory
+++ b/kubeinit/inventory
@@ -67,20 +67,34 @@ kubeinit_inventory_post_deployment_services="none"
 # The cluster's guest machines can be distributed across mutiple hosts. By default they
 # will be deployed in the first Hypervisor. These hypervisors are activated and used
 # depending on how they are referenced in the kubeinit spec string.
+
 [hypervisor_hosts]
 hypervisor-01 ansible_host=nyctea
 hypervisor-02 ansible_host=tyto
 
-# The cluster will have one host identified as the bastion host By default, this role will
+# The inventory will have one host identified as the bastion host. By default, this role will
 # be assumed by the first hypervisor, which is the same behavior as the first commented out
 # line. The second commented out line would set the second hypervisor to be the bastion host.
 # The final commented out line would set the bastion host to be a different host that is not
-# being used as a hypervisor for the guests VMs for this cluster.
+# being used as a hypervisor for the guests VMs for the clusters using this inventory.
 
 [bastion_host]
 # bastion target=hypervisor-01
 # bastion target=hypervisor-02
 # bastion ansible_host=bastion
+
+# The inventory will have one host identified as the ovn-central host.  By default, this role
+# will be assumed by the first hypervisor, which is the same behavior as the first commented
+# out line.  The second commented out line would set the second hypervisor to be the ovn-central
+# host.
+
+[ovn_central_host]
+# ovn-central target=hypervisor-01
+# ovn-central target=hypervisor-02
+
+#
+# Cluster node definitions
+#
 
 # Controller, compute, and extra nodes can be configured as virtual machines or using the
 # manually provisioned baremetal machines for the deployment.

--- a/kubeinit/roles/kubeinit_apache/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_apache/tasks/main.yml
@@ -20,34 +20,44 @@
     name: "buildah"
 
 - name: Create a new working container image
-  ansible.builtin.command: buildah from --name buildah-apache docker.io/httpd:2.4
+  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-apache docker.io/httpd:2.4
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Update the container
-  ansible.builtin.command: buildah run buildah-apache -- apt-get -y update
+  ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-apache -- apt-get -y update
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Replace port 80 with 8080
-  ansible.builtin.command: buildah run buildah-apache -- sed -i -e 's/^Listen 80$/Listen 8080/' /usr/local/apache2/conf/httpd.conf
+  ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-apache -- sed -i -e 's/^Listen 80$/Listen 8080/' /usr/local/apache2/conf/httpd.conf
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create link to kubeinit folder
-  ansible.builtin.command: buildah run buildah-apache -- ln -s /var/kubeinit/html/ /usr/local/apache2/htdocs/kubeinit
+  ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-apache -- ln -s /var/kubeinit/html/ /usr/local/apache2/htdocs/kubeinit
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Set kubeinit-cluster-name label
+  ansible.builtin.command: buildah config --label kubeinit-cluster-name={{ kubeinit_cluster_name }} {{ kubeinit_cluster_name }}-apache
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Commit the container image
-  ansible.builtin.command: buildah commit buildah-apache kubeinit/kubeinit-apache:latest
+  ansible.builtin.command: buildah commit {{ kubeinit_cluster_name }}-apache kubeinit/{{ kubeinit_cluster_name }}-apache:latest
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Remove the buildah container
+  ansible.builtin.command: buildah rm {{ kubeinit_cluster_name }}-apache
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create a podman container to serve the Apache server
   containers.podman.podman_container:
     name: "{{ kubeinit_apache_service_name }}"
-    image: kubeinit/kubeinit-apache:latest
+    image: kubeinit/{{ kubeinit_cluster_name }}-apache:latest
     state: stopped
     pod: "{{ kubeinit_deployment_pod_name }}"
     volumes:

--- a/kubeinit/roles/kubeinit_bind/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_bind/tasks/main.yml
@@ -37,29 +37,39 @@
 - name: Remove any old bind buildah container
   ansible.builtin.shell: |
     set -o pipefail
-    buildah rm buildah-bind || true
+    buildah rm {{ kubeinit_cluster_name }}-bind || true
   args:
     executable: /bin/bash
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create a new working container image
-  ansible.builtin.command: buildah from --name buildah-bind --volume {{ kubeinit_bind_directory }}:/bind-config:Z docker.io/internetsystemsconsortium/bind9:9.11
+  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-bind --volume {{ kubeinit_bind_directory }}:/bind-config:Z docker.io/internetsystemsconsortium/bind9:9.11
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Update the container
-  ansible.builtin.command: buildah run buildah-bind -- apt-get -y update
+  ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-bind -- apt-get -y update
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Copy original contents to /bind-config folder
-  ansible.builtin.command: buildah run buildah-bind -- cp -pr /etc/bind/. /bind-config/.
+  ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-bind -- cp -pr /etc/bind/. /bind-config/.
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Set kubeinit-cluster-name label
+  ansible.builtin.command: buildah config --label kubeinit-cluster-name={{ kubeinit_cluster_name }} {{ kubeinit_cluster_name }}-bind
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Commit the container image
-  ansible.builtin.command: buildah commit buildah-bind kubeinit/kubeinit-bind:latest
+  ansible.builtin.command: buildah commit {{ kubeinit_cluster_name }}-bind kubeinit/{{ kubeinit_cluster_name }}-bind:latest
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Remove the buildah container
+  ansible.builtin.command: buildah rm {{ kubeinit_cluster_name }}-bind
   register: _result
   changed_when: "_result.rc == 0"
 
@@ -96,7 +106,7 @@
 - name: Create a podman container to serve the Bind server
   containers.podman.podman_container:
     name: "{{ kubeinit_bind_service_name }}"
-    image: kubeinit/kubeinit-bind:latest
+    image: kubeinit/{{ kubeinit_cluster_name }}-bind:latest
     pod: "{{ kubeinit_deployment_pod_name }}"
     state: stopped
     volumes:

--- a/kubeinit/roles/kubeinit_bind/templates/create-external-ingress.sh.j2
+++ b/kubeinit/roles/kubeinit_bind/templates/create-external-ingress.sh.j2
@@ -23,12 +23,14 @@ fi
 # configuration assets from the docker hub container image
 rm -rf /var/kubeinit/bind
 mkdir -p /var/kubeinit/bind
-if [ "$(buildah ls --filter 'name=buildah-external' --format {% raw %}'{{ .ContainerName }}'{% endraw %})" != "" ]; then buildah rm buildah-external; fi
-buildah from --name buildah-external -v /var/kubeinit/bind:/var/kubeinit/bind:Z docker.io/internetsystemsconsortium/bind9:9.11
-buildah run buildah-external -- apt-get update -y
-buildah run buildah-external -- apt-get install -y openssh-client
-buildah run buildah-external -- cp -pr /etc/bind/. /var/kubeinit/bind/.
-buildah commit buildah-external kubeinit/kubeinit-ingress-bind
+if [ "$(buildah ls --filter 'name={{ kubeinit_cluster_name }}-external' --format {% raw %}'{{ .ContainerName }}'{% endraw %})" != "" ]; then buildah rm {{ kubeinit_cluster_name }}-external; fi
+buildah from --name {{ kubeinit_cluster_name }}-external -v /var/kubeinit/bind:/var/kubeinit/bind:Z docker.io/internetsystemsconsortium/bind9:9.11
+buildah run {{ kubeinit_cluster_name }}-external -- apt-get update -y
+buildah run {{ kubeinit_cluster_name }}-external -- apt-get install -y openssh-client
+buildah run {{ kubeinit_cluster_name }}-external -- cp -pr /etc/bind/. /var/kubeinit/bind/.
+buildah config --label kubeinit-cluster-name={{ kubeinit_cluster_name }} {{ kubeinit_cluster_name }}-external
+buildah commit {{ kubeinit_cluster_name }}-external kubeinit/{{ kubeinit_cluster_name }}-ingress-bind
+buildah rm {{ kubeinit_cluster_name }}-external
 
 # Remove default-zones include from named.conf
 sed -i -e '/include "\/etc\/bind\/named.conf.default-zones\";/d' /var/kubeinit/bind/named.conf
@@ -87,7 +89,7 @@ if podman container exists {{ kubeinit_cluster_name }}-ingress-bind; then podman
 # Create a volume to provide a cache for the bind server
 if [ "$(podman volume ls --filter 'name={{ kubeinit_cluster_name }}-bind-cache' --format {% raw %}'{{ .Name }}'{% endraw %})" != "" ]; then podman volume rm {{ kubeinit_cluster_name }}-bind-cache; fi
 podman volume create {{ kubeinit_cluster_name }}-bind-cache
-podman run --rm --name {{ kubeinit_cluster_name }}-set-bind-cache-owner -v {{ kubeinit_cluster_name }}-bind-cache:/var/cache/bind:Z kubeinit/kubeinit-ingress-bind chown bind:bind /var/cache/bind
+podman run --rm --name {{ kubeinit_cluster_name }}-set-bind-cache-owner -v {{ kubeinit_cluster_name }}-bind-cache:/var/cache/bind:Z kubeinit/{{ kubeinit_cluster_name }}-ingress-bind chown bind:bind /var/cache/bind
 
 # Create a pod for our container with dns nameserver and search options
 # If you would also like to add a container running VNC you can add this option to the end of the command on the next line: -p ${KUBEINIT_INGRESS_IP}:5901:5901
@@ -102,7 +104,7 @@ else
 fi
 
 # Run the ingress container on the host network mounting required volumes
-podman run --rm -d --pod {{ kubeinit_cluster_name }}-ingress-pod --name {{ kubeinit_cluster_name }}-ingress-bind --network host -v /root/.ssh:/root/.ssh:${overlay} -v /var/kubeinit/bind:/etc/bind:Z -v {{ kubeinit_cluster_name }}-bind-cache:/var/cache/bind:Z kubeinit/kubeinit-ingress-bind
+podman run --rm -d --pod {{ kubeinit_cluster_name }}-ingress-pod --name {{ kubeinit_cluster_name }}-ingress-bind --network host -v /root/.ssh:/root/.ssh:${overlay} -v /var/kubeinit/bind:/etc/bind:Z -v {{ kubeinit_cluster_name }}-bind-cache:/var/cache/bind:Z kubeinit/{{ kubeinit_cluster_name }}-ingress-bind
 
 # Create ssh tunnels in the running container for all the ports served by the cluster haproxy service
 podman exec {{ kubeinit_cluster_name }}-ingress-bind ssh -i ~/.ssh/{{ kubeinit_cluster_name }}_id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=accept-new -N -f -L ${KUBEINIT_INGRESS_IP}:80:${KUBEINIT_HAPROXY_IP}:80 -L ${KUBEINIT_INGRESS_IP}:443:${KUBEINIT_HAPROXY_IP}:443 -L ${KUBEINIT_INGRESS_IP}:6443:${KUBEINIT_HAPROXY_IP}:6443 -L ${KUBEINIT_INGRESS_IP}:8443:${KUBEINIT_HAPROXY_IP}:8443 -L ${KUBEINIT_INGRESS_IP}:9000:${KUBEINIT_HAPROXY_IP}:9000 -L ${KUBEINIT_INGRESS_IP}:22623:${KUBEINIT_HAPROXY_IP}:22623 root@${KUBEINIT_HAPROXY_IP}

--- a/kubeinit/roles/kubeinit_cdk/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_cdk/tasks/main.yml
@@ -21,10 +21,9 @@
     public: yes
   loop: "{{ groups['all_cluster_nodes'] + groups['all_extra_nodes'] }}"
   loop_control:
-    loop_var: cluster_role_item
+    loop_var: kubeinit_deployment_node_name
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
+    kubeinit_deployment_delegate: "{{ hostvars[kubeinit_deployment_node_name].target }}"
   when: kubeinit_cluster_nodes_deployed is not defined or not kubeinit_cluster_nodes_deployed
 
 - name: Render the cluster template

--- a/kubeinit/roles/kubeinit_dnsmasq/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_dnsmasq/tasks/main.yml
@@ -43,36 +43,46 @@
 - name: Remove any old dnsmasq buildah container
   ansible.builtin.shell: |
     set -o pipefail
-    buildah rm buildah-dnsmasq || true
+    buildah rm {{ kubeinit_cluster_name }}-dnsmasq || true
   args:
     executable: /bin/bash
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create a new working container image
-  ansible.builtin.command: buildah from --name buildah-dnsmasq quay.io/poseidon/dnsmasq
+  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-dnsmasq quay.io/poseidon/dnsmasq
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Update the container
-  ansible.builtin.command: buildah run buildah-dnsmasq -- apk upgrade
+  ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-dnsmasq -- apk upgrade
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Copy generated dnsmasq.conf into container
-  ansible.builtin.command: buildah copy buildah-dnsmasq {{ kubeinit_dnsmasq_config_file }} /etc/dnsmasq.conf
+  ansible.builtin.command: buildah copy {{ kubeinit_cluster_name }}-dnsmasq {{ kubeinit_dnsmasq_config_file }} /etc/dnsmasq.conf
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Set kubeinit-cluster-name label
+  ansible.builtin.command: buildah config --label kubeinit-cluster-name={{ kubeinit_cluster_name }} {{ kubeinit_cluster_name }}-dnsmasq
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Commit the container image
-  ansible.builtin.command: buildah commit buildah-dnsmasq kubeinit/kubeinit-dnsmasq:latest
+  ansible.builtin.command: buildah commit {{ kubeinit_cluster_name }}-dnsmasq kubeinit/{{ kubeinit_cluster_name }}-dnsmasq:latest
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Remove the buildah container
+  ansible.builtin.command: buildah rm {{ kubeinit_cluster_name }}-dnsmasq
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create a podman container to serve the dnsmasq
   containers.podman.podman_container:
     name: "{{ kubeinit_dnsmasq_service_name }}"
-    image: kubeinit/kubeinit-dnsmasq:latest
+    image: kubeinit/{{ kubeinit_cluster_name }}-dnsmasq:latest
     pod: "{{ kubeinit_deployment_pod_name }}"
     state: stopped
     cap_add:

--- a/kubeinit/roles/kubeinit_eks/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/main.yml
@@ -21,10 +21,9 @@
     public: yes
   loop: "{{ groups['all_cluster_nodes'] }}"
   loop_control:
-    loop_var: cluster_role_item
+    loop_var: kubeinit_deployment_node_name
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
+    kubeinit_deployment_delegate: "{{ hostvars[kubeinit_deployment_node_name].target }}"
   when: kubeinit_cluster_nodes_deployed is not defined or not kubeinit_cluster_nodes_deployed
 
 - name: Copy cert to pki directory

--- a/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
@@ -37,36 +37,46 @@
 - name: Remove any old haproxy buildah container
   ansible.builtin.shell: |
     set -o pipefail
-    buildah rm buildah-haproxy || true
+    buildah rm {{ kubeinit_cluster_name }}-haproxy || true
   args:
     executable: /bin/bash
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create a new working container image
-  ansible.builtin.command: buildah from --name buildah-haproxy docker.io/library/haproxy:2.3
+  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-haproxy docker.io/library/haproxy:2.3
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Update the container
-  ansible.builtin.command: buildah run buildah-haproxy -- apt-get -y update
+  ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-haproxy -- apt-get -y update
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Copy generated haproxy.cfg into container
-  ansible.builtin.command: buildah copy buildah-haproxy {{ kubeinit_haproxy_config_file }} /usr/local/etc/haproxy/haproxy.cfg
+  ansible.builtin.command: buildah copy {{ kubeinit_cluster_name }}-haproxy {{ kubeinit_haproxy_config_file }} /usr/local/etc/haproxy/haproxy.cfg
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Set kubeinit-cluster-name label
+  ansible.builtin.command: buildah config --label kubeinit-cluster-name={{ kubeinit_cluster_name }} {{ kubeinit_cluster_name }}-haproxy
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Commit the container image
-  ansible.builtin.command: buildah commit buildah-haproxy kubeinit/kubeinit-haproxy:latest
+  ansible.builtin.command: buildah commit {{ kubeinit_cluster_name }}-haproxy kubeinit/{{ kubeinit_cluster_name }}-haproxy:latest
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Remove the buildah container
+  ansible.builtin.command: buildah rm {{ kubeinit_cluster_name }}-haproxy
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create a podman container to serve the haproxy
   containers.podman.podman_container:
     name: "{{ kubeinit_haproxy_service_name }}"
-    image: kubeinit/kubeinit-haproxy:latest
+    image: kubeinit/{{ kubeinit_cluster_name }}-haproxy:latest
     pod: "{{ kubeinit_deployment_pod_name }}"
     state: stopped
     volumes:

--- a/kubeinit/roles/kubeinit_k8s/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/main.yml
@@ -21,10 +21,9 @@
     public: yes
   loop: "{{ groups['all_cluster_nodes'] }}"
   loop_control:
-    loop_var: cluster_role_item
+    loop_var: kubeinit_deployment_node_name
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
+    kubeinit_deployment_delegate: "{{ hostvars[kubeinit_deployment_node_name].target }}"
   when: kubeinit_cluster_nodes_deployed is not defined or not kubeinit_cluster_nodes_deployed
 
 - name: Setup the first controller node

--- a/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
@@ -124,6 +124,3 @@ kubeinit_libvirt_hypervisor_dependencies:
     - inetutils-ping
     - libxml-xpath-perl
     - jq
-
-kubeinit_libvirt_multicluster_keep_predefined_networks: False
-kubeinit_libvirt_destroy_nets: True

--- a/kubeinit/roles/kubeinit_libvirt/tasks/cleanup_libvirt.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/cleanup_libvirt.yml
@@ -15,120 +15,212 @@
 # under the License.
 
 #
-# Cleanup OVN network
+# Cleanup VMs created during task-deploy-cluster
 #
 
-- name: Clean OVN/OVS resources (route)
-  ansible.builtin.command: ip route del {{ kubeinit_cluster_network }} via 172.16.0.1 dev br-ex
-  ignore_errors: true
-  register: _result
-  changed_when: "_result.rc == 0"
-  loop: "{{ groups['all_hosts'] }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-  delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: >
-    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+- name: Generate a list of vm guest names to match
+  ansible.builtin.set_fact:
+    matching_vm_guest_names: "{{ (matching_vm_guest_names | default([])) | union([hostvars[item].guest_name]) }}"
+  loop: "{{ groups['all_guest_vms'] }}"
 
-- name: Clean OVN/OVS resources (sw0)
-  ansible.builtin.command: /usr/bin/ovn-nbctl --if-exists ls-del sw0
-  ignore_errors: true
-  register: _result
-  changed_when: "_result.rc == 0"
-  loop: "{{ groups['all_hosts'] }}"
-  loop_control:
-    loop_var: cluster_role_item
+- name: Destroy vms
+  community.libvirt.virt:
+    name: "{{ cluster_vm }}"
+    state: destroyed
+  loop: "{{ kubeinit_cluster_hostvars.running_vms }}"
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    cluster_vm: "{{ item[1] }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: >
-    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+  when: cluster_vm in matching_vm_guest_names or kubeinit_libvirt_destroy_all_guests
 
-- name: Clean OVN/OVS resources (lr0)
-  ansible.builtin.command: /usr/bin/ovn-nbctl --if-exists lr-del lr0
-  ignore_errors: true
-  register: _result
-  changed_when: "_result.rc == 0"
-  loop: "{{ groups['all_hosts'] }}"
-  loop_control:
-    loop_var: cluster_role_item
+- name: Undefine vms
+  community.libvirt.virt:
+    name: "{{ cluster_vm }}"
+    command: undefine
+  loop: "{{ kubeinit_cluster_hostvars.running_vms }}"
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    cluster_vm: "{{ item[1] }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: >
-    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+  when: cluster_vm in matching_vm_guest_names or kubeinit_libvirt_destroy_all_guests
 
-- name: Clean OVN/OVS resources (public)
-  ansible.builtin.command: /usr/bin/ovn-nbctl --if-exists ls-del public
-  ignore_errors: true
-  register: _result
-  changed_when: "_result.rc == 0"
+- name: Remove VMs storage
+  ansible.builtin.file:
+    state: absent
+    path: "{{ kubeinit_libvirt_target_image_dir }}/{{ cluster_vm }}.qcow2"
+  loop: "{{ kubeinit_cluster_hostvars.running_vms }}"
+  vars:
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    cluster_vm: "{{ item[1] }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: cluster_vm in matching_vm_guest_names or kubeinit_libvirt_destroy_all_guests
+
+#
+# Cleanup guest vm folders created during task-download-images
+#
+- name: Clean directories for config files per node
+  ansible.builtin.file:
+    state: absent
+    path: "{{ kubeinit_libvirt_hypervisor_tmp_dir }}/{{ guest_vm }}/"
+  loop: "{{ groups['all_hosts'] | product(groups['all_guest_vms']) }}"
+  vars:
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    guest_vm: "{{ hostvars[item[1]].guest_name }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+
+#
+# Cleanup libvirt networks created during task-create-network
+#
+- name: Destroy deployment networks
+  community.libvirt.virt_net:
+    command: destroy
+    name: "{{ kubeinit_cluster_network_name }}"
   loop: "{{ groups['all_hosts'] }}"
   loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    loop_var: kubeinit_deployment_node_name
   delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: >
-    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+  when: kubeinit_cluster_network_name in hostvars[kubeinit_deployment_node_name].libvirt_nets
+
+- name: Undefine deployment networks
+  community.libvirt.virt_net:
+    command: undefine
+    name: "{{ kubeinit_cluster_network_name }}"
+  loop: "{{ groups['all_hosts'] }}"
+  loop_control:
+    loop_var: kubeinit_deployment_node_name
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: kubeinit_cluster_network_name in hostvars[kubeinit_deployment_node_name].libvirt_nets
+
+- name: Remove the deployment networks
+  community.libvirt.virt_net:
+    state: absent
+    name: "{{ kubeinit_cluster_network_name }}"
+  loop: "{{ groups['all_hosts'] }}"
+  loop_control:
+    loop_var: kubeinit_deployment_node_name
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: kubeinit_cluster_network_name in hostvars[kubeinit_deployment_node_name].libvirt_nets
+
+#
+# Cleanup OVN network resources for this cluster created during task-create-network
+#
+
+- name: Default is to remove the OVN network if it is no longer in use
+  ansible.builtin.set_fact:
+    kubeinit_destroy_ovn_network: true
+
+- name: Delegate to ovn-central host
+  block:
+
+    - name: Remove route for cluster network via br-ex
+      ansible.builtin.command: ip route del {{ kubeinit_cluster_network }} via 172.16.0.1 dev br-ex
+      register: _result
+      changed_when: "_result.rc == 0"
+      failed_when: _result is not defined
+
+    - name: Remove logical router port of the logical switch for this cluster
+      ansible.builtin.command: /usr/bin/ovn-nbctl --if-exists lrp-del lr0-sw-{{ kubeinit_cluster_name }}
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Remove switch for this cluster
+      ansible.builtin.command: /usr/bin/ovn-nbctl --if-exists ls-del sw-{{ kubeinit_cluster_name }}
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Wait for changes to propagate
+      ansible.builtin.command: /usr/bin/ovn-nbctl --wait=hv --timeout=30 sync
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: See if any other networks are routing via br-ex
+      ansible.builtin.command: ip route list dev br-ex
+      register: _result
+      changed_when: "_result.rc == 0"
+      failed_when: _result is not defined
+
+    - name: Leave OVN network alone if there are signs of other cluster networks
+      ansible.builtin.set_fact:
+        kubeinit_destroy_ovn_network: false
+      when: _result.stdout_lines | length > 1
+
+    - name: See if any other cluster switches have ports on lr0
+      ansible.builtin.command: /usr/bin/ovn-nbctl lrp-list lr0
+      register: _result
+      changed_when: "_result.rc == 0"
+      failed_when: _result is not defined
+
+    - name: Leave OVN network alone if there are signs of other cluster networks
+      ansible.builtin.set_fact:
+        kubeinit_destroy_ovn_network: false
+      when: _result.stdout_lines | length > 1
+
+    - name: See if any other cluster switches are defined
+      ansible.builtin.command: /usr/bin/ovn-nbctl ls-list
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Leave OVN network alone if there are signs of other cluster networks
+      ansible.builtin.set_fact:
+        kubeinit_destroy_ovn_network: false
+      when: _result.stdout_lines | length > 1
+
+    - name: Remove logical router if tearing down OVN network
+      ansible.builtin.command: /usr/bin/ovn-nbctl --if-exists lr-del lr0
+      register: _result
+      changed_when: "_result.rc == 0"
+      when: kubeinit_destroy_ovn_network
+
+    - name: Clean OVN/OVS resources (public)
+      ansible.builtin.command: /usr/bin/ovn-nbctl --if-exists ls-del public
+      register: _result
+      changed_when: "_result.rc == 0"
+      when: kubeinit_destroy_ovn_network
+
+  delegate_to: "{{ kubeinit_ovn_central_host }}"
+  when: hostvars[kubeinit_ovn_central_host].ovs_is_active
 
 - name: Clean OVN/OVS resources (br-int)
   openvswitch.openvswitch.openvswitch_bridge:
     bridge: br-int
     state: absent
-  ignore_errors: true
   loop: "{{ groups['all_hosts'] }}"
   loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    loop_var: kubeinit_deployment_node_name
   delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: >
-    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+  when: hostvars[kubeinit_deployment_node_name].ovs_is_active and kubeinit_destroy_ovn_network
 
 - name: Clean OVN/OVS resources (br-ex)
   openvswitch.openvswitch.openvswitch_bridge:
     bridge: br-ex
     state: absent
-  ignore_errors: true
   loop: "{{ groups['all_hosts'] }}"
   loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    loop_var: kubeinit_deployment_node_name
   delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: >
-    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+  when: hostvars[kubeinit_deployment_node_name].ovs_is_active and kubeinit_destroy_ovn_network
 
 - name: Clean OVN/OVS resources (genev_sys_6081)
   ansible.builtin.command: ip link del genev_sys_6081
-  ignore_errors: true
   register: _result
   changed_when: "_result.rc == 0"
+  failed_when: _result is not defined
   loop: "{{ groups['all_hosts'] }}"
   loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    loop_var: kubeinit_deployment_node_name
   delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: >
-    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+  when: hostvars[kubeinit_deployment_node_name].ovs_is_active and kubeinit_destroy_ovn_network
 
 - name: Clean OVN/OVS resources (ovs-system)
   ansible.builtin.command: ovs-dpctl del-dp ovs-system
-  ignore_errors: true
   register: _result
   changed_when: "_result.rc == 0"
   loop: "{{ groups['all_hosts'] }}"
   loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    loop_var: kubeinit_deployment_node_name
   delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: >
-    kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+  when: hostvars[kubeinit_deployment_node_name].ovs_is_active and kubeinit_destroy_ovn_network
 
 - name: Stop and disable OVN services in the first hypervisor (CentOS based)
   ansible.builtin.service:
@@ -138,13 +230,12 @@
   register: _result_stop_service
   failed_when: _result_stop_service is not defined
   loop: "{{ groups['all_hosts'] | product(['openvswitch', 'ovn-northd', 'ovn-controller']) }}"
-  loop_control:
-    loop_var: cluster_role_item
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    service_name: "{{ cluster_role_item[1] }}"
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    service_name: "{{ item[1] }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
   when: >
+    kubeinit_destroy_ovn_network and
     (kubeinit_deployment_node_name in kubeinit_ovn_central_host) and
     (hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS' or hostvars[kubeinit_deployment_node_name].distribution_family == 'Fedora')
 
@@ -156,13 +247,12 @@
   register: _result_stop_service
   failed_when: _result_stop_service is not defined
   loop: "{{ groups['all_hosts'] | product(['openvswitch', 'ovn-controller']) }}"
-  loop_control:
-    loop_var: cluster_role_item
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    service_name: "{{ cluster_role_item[1] }}"
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    service_name: "{{ item[1] }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
   when: >
+    kubeinit_destroy_ovn_network and
     (kubeinit_deployment_node_name not in kubeinit_ovn_central_host) and
     (hostvars[kubeinit_deployment_node_name].distribution_family == 'CentOS' or hostvars[kubeinit_deployment_node_name].distribution_family == 'Fedora')
 
@@ -173,14 +263,13 @@
     enabled: false
   register: _result_stop_service
   failed_when: _result_stop_service is not defined
-  loop: "{{ groups['all_hosts'] | product(['ovs-vswitchd', 'ovn-central', 'ovn-controller']) }}"
-  loop_control:
-    loop_var: cluster_role_item
+  loop: "{{ groups['all_hosts'] | product(['openvswitch-switch', 'ovn-host', 'ovn-central']) }}"
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    service_name: "{{ cluster_role_item[1] }}"
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    service_name: "{{ item[1] }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
   when: >
+    kubeinit_destroy_ovn_network and
     (kubeinit_deployment_node_name in kubeinit_ovn_central_host) and
     (hostvars[kubeinit_deployment_node_name].distribution_family == 'Debian')
 
@@ -191,14 +280,13 @@
     enabled: false
   register: _result_stop_service
   failed_when: _result_stop_service is not defined
-  loop: "{{ groups['all_hosts'] | product(['ovs-vswitchd', 'ovn-controller']) }}"
-  loop_control:
-    loop_var: cluster_role_item
+  loop: "{{ groups['all_hosts'] | product(['openswitch-switch', 'ovn-host']) }}"
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    service_name: "{{ cluster_role_item[1] }}"
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    service_name: "{{ item[1] }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
   when: >
+    kubeinit_destroy_ovn_network and
     (kubeinit_deployment_node_name not in kubeinit_ovn_central_host) and
     (hostvars[kubeinit_deployment_node_name].distribution_family == 'Debian')
 
@@ -207,125 +295,8 @@
     path: "{{ dir_name }}"
     state: absent
   loop: "{{ groups['all_hosts'] | product(['/etc/openvswitch/conf.db', '/etc/openvswitch/system-id.conf', '/var/lib/ovn/']) }}"
-  loop_control:
-    loop_var: cluster_role_item
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    dir_name: "{{ cluster_role_item[1] }}"
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    dir_name: "{{ item[1] }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
-
-#
-# Cleanup libvirt networks
-#
-- name: Destroy deployment networks
-  community.libvirt.virt_net:
-    command: destroy
-    name: "{{ kubeinit_cluster_network_name }}"
-  loop: "{{ groups['all_hosts'] }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-  delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: kubeinit_cluster_network_name in hostvars[kubeinit_deployment_node_name].libvirt_nets and kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
-
-- name: Undefine deployment networks
-  community.libvirt.virt_net:
-    command: undefine
-    name: "{{ kubeinit_cluster_network_name }}"
-  loop: "{{ groups['all_hosts'] }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-  delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: kubeinit_cluster_network_name in hostvars[kubeinit_deployment_node_name].libvirt_nets and kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
-
-- name: Remove the deployment networks
-  community.libvirt.virt_net:
-    state: absent
-    name: "{{ kubeinit_cluster_network_name }}"
-  loop: "{{ groups['all_hosts'] }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-  delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: kubeinit_cluster_network_name in hostvars[kubeinit_deployment_node_name].libvirt_nets and kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
-
-#
-# Cleanup VMs
-#
-- name: Generate a list of vm guest names to match
-  ansible.builtin.set_fact:
-    matching_vm_guest_names: "{{ (matching_vm_guest_names | default([])) | union([hostvars[item].guest_name]) }}"
-  loop: "{{ groups['all_guest_vms'] }}"
-
-- name: Destroy vms
-  community.libvirt.virt:
-    name: "{{ cluster_vm }}"
-    state: destroyed
-  loop: "{{ kubeinit_cluster_hostvars.running_vms }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    cluster_vm: "{{ cluster_role_item[1] }}"
-  delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: cluster_vm in matching_vm_guest_names or kubeinit_libvirt_destroy_all_guests
-
-- name: Undefine vms
-  community.libvirt.virt:
-    name: "{{ cluster_vm }}"
-    command: undefine
-  loop: "{{ kubeinit_cluster_hostvars.running_vms }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    cluster_vm: "{{ cluster_role_item[1] }}"
-  delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: cluster_vm in matching_vm_guest_names or kubeinit_libvirt_destroy_all_guests
-
-- name: Remove VMs storage
-  ansible.builtin.file:
-    state: absent
-    path: "{{ kubeinit_libvirt_target_image_dir }}/{{ cluster_vm }}.qcow2"
-  loop: "{{ kubeinit_cluster_hostvars.running_vms }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    cluster_vm: "{{ cluster_role_item[1] }}"
-  delegate_to: "{{ kubeinit_deployment_node_name }}"
-  when: cluster_vm in matching_vm_guest_names or kubeinit_libvirt_destroy_all_guests
-
-#
-# Cleanup guest vm folders
-#
-- name: Clean directories for config files per node
-  ansible.builtin.file:
-    state: absent
-    path: "{{ kubeinit_libvirt_hypervisor_tmp_dir }}/{{ guest_vm }}/"
-  loop: "{{ groups['all_hosts'] | product(groups['all_guest_vms']) }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    guest_vm: "{{ hostvars[cluster_role_item[1]].guest_name }}"
-  delegate_to: "{{ kubeinit_deployment_node_name }}"
-
-#
-# Clean keys
-#
-- name: Reset ssh keys in hypervisor
-  ansible.builtin.known_hosts:
-    name: "{{ node_alias }}"
-    state: absent
-  loop: "{{ groups['all_hosts'] | product(kubeinit_cluster_hostvars.node_aliases | flatten | unique) }}"
-  loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    node_alias: "{{ cluster_role_item[1] }}"
-  delegate_to: "{{ kubeinit_deployment_node_name }}"
+  when: kubeinit_destroy_ovn_network

--- a/kubeinit/roles/kubeinit_libvirt/tasks/create_network.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/create_network.yml
@@ -182,53 +182,74 @@
   delegate_to: "{{ ovn_host }}"
   when: hostvars[ovn_host].firewalld_is_active
 
-- name: Enable and start OVN services in the ovn-central hypervisor (CentOS based)
-  ansible.builtin.service:
-    name: "{{ item }}"
-    state: restarted
-    enabled: yes
-  loop:
-    - openvswitch
-    - ovn-northd
-    - ovn-controller
+- name: Only restart if this is the only cluster network
+  block:
+
+    - name: Enable and start OVN services in the ovn-central hypervisor (CentOS based)
+      ansible.builtin.service:
+        name: "{{ item }}"
+        state: started
+        enabled: yes
+      loop:
+        - openvswitch
+        - ovn-northd
+        - ovn-controller
+      delegate_to: "{{ kubeinit_ovn_central_host }}"
+      when: hostvars[kubeinit_ovn_central_host].distribution_family != 'Debian'
+
+    - name: Enable and start OVN services in the rest of the hypervisors (CentOS based)
+      ansible.builtin.service:
+        name: "{{ service_name }}"
+        state: started
+        enabled: yes
+      loop: "{{ kubeinit_other_ovn_hosts | default([]) | product(['openvswitch', 'ovn-controller']) }}"
+      vars:
+        ovn_host: "{{ item[0] }}"
+        service_name: "{{ item[1] }}"
+      delegate_to: "{{ ovn_host }}"
+      when: hostvars[ovn_host].distribution_family != 'Debian'
+
+    - name: Enable and start OVN services in the ovn-central hypervisor (Debian/Ubuntu based)
+      ansible.builtin.service:
+        name: "{{ item }}"
+        state: started
+        enabled: yes
+      loop:
+        - openvswitch-switch
+        - ovn-host
+        - ovn-central
+      delegate_to: "{{ kubeinit_ovn_central_host }}"
+      when: hostvars[kubeinit_ovn_central_host].distribution_family == 'Debian'
+
+    - name: Enable and start OVN services in the rest of the hypervisors (Debian/Ubuntu based)
+      ansible.builtin.service:
+        name: "{{ service_name }}"
+        state: started
+        enabled: yes
+      loop: "{{ kubeinit_other_ovn_hosts | default([]) | product(['openvswitch-switch', 'ovn-host']) }}"
+      vars:
+        ovn_host: "{{ item[0] }}"
+        service_name: "{{ item[1] }}"
+      delegate_to: "{{ ovn_host }}"
+      when: hostvars[ovn_host].distribution_family == 'Debian'
+
+    - name: Wait until OVN services are running
+      ansible.builtin.command: /usr/share/ovn/scripts/ovn-ctl status_northd
+      register: _result
+      changed_when: "_result.rc == 0"
+      retries: 6
+      delay: 10
+      delegate_to: "{{ kubeinit_ovn_central_host }}"
+      until: "'ovn-northd is running' in _result.stdout"
+
+  when: kubeinit_destroy_ovn_network
+
+- name: Wait for changes to propagate
+  ansible.builtin.command: |
+    /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 sync
+  register: _result
+  changed_when: "_result.rc == 0"
   delegate_to: "{{ kubeinit_ovn_central_host }}"
-  when: hostvars[kubeinit_ovn_central_host].distribution_family != 'Debian'
-
-- name: Enable and start OVN services in the rest of the hypervisors (CentOS based)
-  ansible.builtin.service:
-    name: "{{ service_name }}"
-    state: restarted
-    enabled: yes
-  loop: "{{ kubeinit_other_ovn_hosts | default([]) | product(['openvswitch', 'ovn-controller']) }}"
-  vars:
-    ovn_host: "{{ item[0] }}"
-    service_name: "{{ item[1] }}"
-  delegate_to: "{{ ovn_host }}"
-  when: hostvars[ovn_host].distribution_family != 'Debian'
-
-- name: Enable and start OVN services in the ovn-central hypervisor (Ubuntu based)
-  ansible.builtin.service:
-    name: "{{ item }}"
-    state: restarted
-    enabled: yes
-  loop:
-    - ovs-vswitchd
-    - ovn-central
-    - ovn-controller
-  delegate_to: "{{ kubeinit_ovn_central_host }}"
-  when: hostvars[kubeinit_ovn_central_host].distribution_family == 'Debian'
-
-- name: Enable and start OVN services in the rest of the hypervisors (Ubuntu based)
-  ansible.builtin.service:
-    name: "{{ service_name }}"
-    state: restarted
-    enabled: yes
-  loop: "{{ kubeinit_other_ovn_hosts | default([]) | product(['ovs-vswitchd', 'ovn-controller']) }}"
-  vars:
-    ovn_host: "{{ item[0] }}"
-    service_name: "{{ item[1] }}"
-  delegate_to: "{{ ovn_host }}"
-  when: hostvars[ovn_host].distribution_family == 'Debian'
 
 - name: Configure OVS on the Hypervisors
   ansible.builtin.shell: |
@@ -252,6 +273,14 @@
   loop_control:
     loop_var: ovn_host
   delegate_to: "{{ ovn_host }}"
+  when: kubeinit_destroy_ovn_network
+
+- name: Wait for changes to propagate
+  ansible.builtin.command: |
+    /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 sync
+  register: _result
+  changed_when: "_result.rc == 0"
+  delegate_to: "{{ kubeinit_ovn_central_host }}"
 
 #
 # OVN post deployment configuration steps.
@@ -268,6 +297,13 @@
         executable: /bin/bash
       register: _result
       changed_when: "_result.rc == 0"
+      when: kubeinit_destroy_ovn_network
+
+    - name: Wait for changes to propagate
+      ansible.builtin.command: |
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 sync
+      register: _result
+      changed_when: "_result.rc == 0"
 
     #
     # We create the OVN switch that will be bound to each chassis (hypervisor)
@@ -278,28 +314,39 @@
         #
         # Create a logical switch
         #
-        /usr/bin/ovn-nbctl ls-del sw0
-        /usr/bin/ovn-nbctl --wait=hv ls-add sw0
+        /usr/bin/ovn-nbctl ls-del sw-{{ kubeinit_cluster_name }}
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 ls-add sw-{{ kubeinit_cluster_name }}
       args:
         executable: /bin/bash
       register: _result
       changed_when: "_result.rc == 0"
-      when: kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
+
+    - name: Wait for changes to propagate
+      ansible.builtin.command: |
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 sync
+      register: _result
+      changed_when: "_result.rc == 0"
 
     - name: Create OVS/OVN bindings for the VMs ports
       ansible.builtin.shell: |
         #
         # We create an OVN port using the interface ID and the mac address of the VM
         #
-        /usr/bin/ovn-nbctl --wait=hv lsp-add sw0 {{ hostvars[item].interfaceid }}
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 lsp-add sw-{{ kubeinit_cluster_name }} {{ hostvars[item].interfaceid }}
         #
         # The port name is the interface id of the VM, now we assign the mac address of the VM to the port
         #
-        /usr/bin/ovn-nbctl --wait=sb lsp-set-addresses {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
-        /usr/bin/ovn-nbctl --wait=sb lsp-set-port-security {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
+        /usr/bin/ovn-nbctl --wait=sb --wait=sb --timeout=30 lsp-set-addresses {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
+        /usr/bin/ovn-nbctl --wait=sb --wait=sb --timeout=30 lsp-set-port-security {{ hostvars[item].interfaceid }} "{{ hostvars[item].mac }} {{ hostvars[item].ansible_host }}"
       args:
         executable: /bin/bash
       loop: "{{ groups['all_nodes'] }}"
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Wait for changes to propagate
+      ansible.builtin.command: |
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 sync
       register: _result
       changed_when: "_result.rc == 0"
 
@@ -308,25 +355,20 @@
         #
         # Create a logical router to connect the VMs switch
         #
-        /usr/bin/ovn-nbctl --wait=hv lr-add lr0
-        /usr/bin/ovn-nbctl --wait=hv lrp-add lr0 lr0-sw0 00:00:00:65:77:09 {{ kubeinit_cluster_gateway }}/{{ kubeinit_cluster_prefix }}
-        /usr/bin/ovn-nbctl --wait=hv lsp-add sw0 sw0-lr0
-        /usr/bin/ovn-nbctl lsp-set-type sw0-lr0 router
-        /usr/bin/ovn-nbctl lsp-set-addresses sw0-lr0 router
-        /usr/bin/ovn-nbctl lsp-set-options sw0-lr0 router-port=lr0-sw0
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 lr-add lr0
         #
         # We create the external access switch
         #
-        /usr/bin/ovn-nbctl --wait=hv ls-add public
-        /usr/bin/ovn-nbctl --wait=hv lrp-add lr0 lr0-public 00:00:20:20:12:13 172.16.0.1/24
-        /usr/bin/ovn-nbctl --wait=hv lsp-add public public-lr0
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 ls-add public
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 lrp-add lr0 lr0-public {{ '00:00:20' | community.general.random_mac }} 172.16.0.1/24
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 lsp-add public public-lr0
         /usr/bin/ovn-nbctl lsp-set-type public-lr0 router
         /usr/bin/ovn-nbctl lsp-set-addresses public-lr0 router
         /usr/bin/ovn-nbctl lsp-set-options public-lr0 router-port=lr0-public
         #
         # Create a localnet port
         #
-        /usr/bin/ovn-nbctl --wait=hv lsp-add public public-ln
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 lsp-add public public-ln
         /usr/bin/ovn-nbctl lsp-set-type public-ln localnet
         /usr/bin/ovn-nbctl lsp-set-addresses public-ln unknown
         /usr/bin/ovn-nbctl lsp-set-options public-ln network_name=provider
@@ -351,8 +393,6 @@
         #
         # Routes
         #
-        # Connectivity from the host to the guest machines
-        ip route add {{ kubeinit_cluster_network }} via 172.16.0.1 dev br-ex
         # Connectivity to external/additional networks
         /usr/bin/ovn-nbctl lr-route-add lr0 0.0.0.0/0 172.16.0.254
         #
@@ -361,6 +401,39 @@
         sysctl net.ipv4.conf.all.rp_filter=2
       args:
         executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+      when: kubeinit_destroy_ovn_network
+
+    - name: Wait for changes to propagate
+      ansible.builtin.command: |
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 sync
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Attach our cluster network to the logical router
+      ansible.builtin.shell: |
+        #
+        # Create a logical router to connect the VMs switch
+        #
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 lrp-add lr0 lr0-sw-{{ kubeinit_cluster_name }} {{ '00:00:00' | community.general.random_mac }} {{ kubeinit_cluster_gateway }}/{{ kubeinit_cluster_prefix }}
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 lsp-add sw-{{ kubeinit_cluster_name }} sw-{{ kubeinit_cluster_name }}-lr0
+        /usr/bin/ovn-nbctl lsp-set-type sw-{{ kubeinit_cluster_name }}-lr0 router
+        /usr/bin/ovn-nbctl lsp-set-addresses sw-{{ kubeinit_cluster_name }}-lr0 router
+        /usr/bin/ovn-nbctl lsp-set-options sw-{{ kubeinit_cluster_name }}-lr0 router-port=lr0-sw-{{ kubeinit_cluster_name }}
+        #
+        # Routes
+        #
+        # Connectivity from the host to the guest machines
+        ip route add {{ kubeinit_cluster_network }} via 172.16.0.1 dev br-ex
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Wait for changes to propagate
+      ansible.builtin.command: |
+        /usr/bin/ovn-nbctl --wait=hv --wait=sb --timeout=30 sync
       register: _result
       changed_when: "_result.rc == 0"
 
@@ -426,7 +499,6 @@
   loop_control:
     loop_var: ovn_host
   delegate_to: "{{ ovn_host }}"
-  when: kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
 
 - name: Activate KubeInit networks
   community.libvirt.virt_net:
@@ -436,7 +508,6 @@
   loop_control:
     loop_var: ovn_host
   delegate_to: "{{ ovn_host }}"
-  when: kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
 
 - name: Autostart KubeInit networks
   community.libvirt.virt_net:
@@ -446,7 +517,6 @@
   loop_control:
     loop_var: ovn_host
   delegate_to: "{{ ovn_host }}"
-  when: kubeinit_libvirt_destroy_nets|bool and not kubeinit_libvirt_multicluster_keep_predefined_networks
 
 - block:
     - name: Add task-create-network to tasks_completed
@@ -459,7 +529,7 @@
         kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-create-network' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play

--- a/kubeinit/roles/kubeinit_libvirt/tasks/download_cloud_images.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/download_cloud_images.yml
@@ -36,9 +36,12 @@
 #
 - name: Create tuples for hosts and guest vms
   ansible.builtin.set_fact:
-    all_hosts_guest_vms: "{{ (all_hosts_guest_vms | default([])) + ([item[0]] | product([item[1]])) }}"
+    all_hosts_guest_vms: "{{ (all_hosts_guest_vms | default([])) + ([hypervisor] | product([guest_vm])) }}"
   loop: "{{ groups['all_hosts'] | product(groups['all_guest_vms']) }}"
-  when: hostvars[item[1]].target in item[0]
+  vars:
+    hypervisor: "{{ item[0] }}"
+    guest_vm: "{{ item[1] }}"
+  when: hostvars[guest_vm].target in hypervisor
 
 - name: Create new directories for config files per node
   ansible.builtin.file:
@@ -55,11 +58,10 @@
 - name: Create tuples for hosts and cloud images
   ansible.builtin.set_fact:
     all_hosts_cloud_images: "{{ (all_hosts_cloud_images | default([])) + ([hypervisor] | product([kubeinit_libvirt_cloud_images[kubeinit_cluster_distro]])) }}"
-  loop: "{{ groups['all_hosts'] | product(groups['all_guest_vms']) }}"
+  loop: "{{ all_hosts_guest_vms }}"
   vars:
     hypervisor: "{{ item[0] }}"
-    guest_vm: "{{ item[1] }}"
-  when: hostvars[guest_vm].target in hypervisor and kubeinit_libvirt_cloud_images[kubeinit_cluster_distro] is defined
+  when: kubeinit_libvirt_cloud_images[kubeinit_cluster_distro] is defined
 
 - name: Remove duplicates
   ansible.builtin.set_fact:
@@ -102,7 +104,7 @@
         kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-download-images' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play

--- a/kubeinit/roles/kubeinit_nexus/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_nexus/tasks/main.yml
@@ -41,7 +41,7 @@
       set -eo pipefail
       cp /opt/sonatype/nexus/etc/nexus-default.properties /nexus-data/etc/nexus.properties
       sed -i -e 's/^\([^#]\)/# \1/' -e 's/^# nexus-args=/nexus-args=/' -e 's/jetty-http/jetty-https/' -e 's/# application-port=8081/application-port-ssl=8443/' -e '$ a ssl.etc=${karaf.data}/etc/ssl' -e '$ a nexus.scripts.allowCreation=true' /nexus-data/etc/nexus.properties
-      sed -i -e '/New id="sslContextFactory"/ a REPLACE_ME' -e 's;REPLACE_ME;    <Set name="certAlias">kubeinit-nexus</Set>;' /opt/sonatype/nexus/etc/jetty/jetty-https.xml
+      sed -i -e '/New id="sslContextFactory"/ a REPLACE_ME' -e 's;REPLACE_ME;    <Set name="certAlias">{{ kubeinit_cluster_name }}-nexus</Set>;' /opt/sonatype/nexus/etc/jetty/jetty-https.xml
     dest: "{{ kubeinit_nexus_directory_data }}/update-props.sh"
     mode: '0644'
 
@@ -53,105 +53,115 @@
 - name: Remove any old nexus buildah container
   ansible.builtin.shell: |
     set -o pipefail
-    buildah rm buildah-nexus || true
+    buildah rm {{ kubeinit_cluster_name }}-nexus || true
   args:
     executable: /bin/bash
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create a new working container image
-  ansible.builtin.command: buildah from --name buildah-nexus --volume "{{ kubeinit_nexus_directory_data }}:/nexus-data" docker.io/sonatype/nexus3:3.30.0
+  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-nexus --volume "{{ kubeinit_nexus_directory_data }}:/nexus-data" docker.io/sonatype/nexus3:3.30.0
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Set working directory inside container
-  ansible.builtin.command: buildah config --workingdir /nexus-data/tmp buildah-nexus
+  ansible.builtin.command: buildah config --workingdir /nexus-data/tmp {{ kubeinit_cluster_name }}-nexus
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Update image
-  ansible.builtin.command: buildah run --user root:root buildah-nexus -- dnf update -q -y
+  ansible.builtin.command: buildah run --user root:root {{ kubeinit_cluster_name }}-nexus -- dnf update -q -y
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create java keystore
-  ansible.builtin.command: buildah run --user root:root buildah-nexus -- keytool -genkeypair -keystore keystore.jks -storepass password -keypass password -alias kubeinit-nexus -keyalg RSA -keysize 2048 -validity 5000 -dname "CN=*.{{ kubeinit_cluster_fqdn }}, OU={{ kubeinit_common_certificate_organizational_unit }}, O={{ kubeinit_common_certificate_organization }}, L={{ kubeinit_common_certificate_locality }}, ST={{ kubeinit_common_certificate_state }}, C={{ kubeinit_common_certificate_country }}" -ext "SAN=DNS:{{ kubeinit_nexus_fqdn }},IP:{{ kubeinit_nexus_service_address }}" -ext "BC=ca:true"
+  ansible.builtin.command: buildah run --user root:root {{ kubeinit_cluster_name }}-nexus -- keytool -genkeypair -keystore keystore.jks -storepass password -keypass password -alias {{ kubeinit_cluster_name }}-nexus -keyalg RSA -keysize 2048 -validity 5000 -dname "CN=*.{{ kubeinit_cluster_fqdn }}, OU={{ kubeinit_common_certificate_organizational_unit }}, O={{ kubeinit_common_certificate_organization }}, L={{ kubeinit_common_certificate_locality }}, ST={{ kubeinit_common_certificate_state }}, C={{ kubeinit_common_certificate_country }}" -ext "SAN=DNS:{{ kubeinit_nexus_fqdn }},IP:{{ kubeinit_nexus_service_address }}" -ext "BC=ca:true"
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Copy keystore file
-  ansible.builtin.command: buildah run --user root:root buildah-nexus -- keytool -importkeystore -srckeystore keystore.jks -srcstorepass password -destkeystore keystore.jks -deststoretype pkcs12
+  ansible.builtin.command: buildah run --user root:root {{ kubeinit_cluster_name }}-nexus -- keytool -importkeystore -srckeystore keystore.jks -srcstorepass password -destkeystore keystore.jks -deststoretype pkcs12
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Copy keystore file
-  ansible.builtin.command: buildah run --user root:root buildah-nexus -- keytool -export -alias kubeinit-nexus -keystore keystore.jks -storepass password -rfc -file public.cert
+  ansible.builtin.command: buildah run --user root:root {{ kubeinit_cluster_name }}-nexus -- keytool -export -alias {{ kubeinit_cluster_name }}-nexus -keystore keystore.jks -storepass password -rfc -file public.cert
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Copy keystore file
-  ansible.builtin.command: buildah run --user root:root buildah-nexus -- cp keystore.jks public.cert /nexus-data/etc/ssl/
+  ansible.builtin.command: buildah run --user root:root {{ kubeinit_cluster_name }}-nexus -- cp keystore.jks public.cert /nexus-data/etc/ssl/
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Link keystore file to alternate location
-  ansible.builtin.command: buildah run --user root:root buildah-nexus -- ln -s /nexus-data/etc/ssl/keystore.jks /opt/sonatype/nexus/etc/ssl/keystore.jks
+  ansible.builtin.command: buildah run --user root:root {{ kubeinit_cluster_name }}-nexus -- ln -s /nexus-data/etc/ssl/keystore.jks /opt/sonatype/nexus/etc/ssl/keystore.jks
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Run script to update properties
-  ansible.builtin.command: buildah run --user root:root buildah-nexus -- bash /nexus-data/update-props.sh
+  ansible.builtin.command: buildah run --user root:root {{ kubeinit_cluster_name }}-nexus -- bash /nexus-data/update-props.sh
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Set owner of nexus data to nexus
-  ansible.builtin.command: buildah run --user root:root buildah-nexus -- chown -R nexus:nexus /nexus-data
+  ansible.builtin.command: buildah run --user root:root {{ kubeinit_cluster_name }}-nexus -- chown -R nexus:nexus /nexus-data
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Set kubeinit-cluster-name label
+  ansible.builtin.command: buildah config --label kubeinit-cluster-name={{ kubeinit_cluster_name }} {{ kubeinit_cluster_name }}-nexus
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Commit the container image
-  ansible.builtin.command: buildah commit buildah-nexus kubeinit/kubeinit-nexus:latest
+  ansible.builtin.command: buildah commit {{ kubeinit_cluster_name }}-nexus kubeinit/{{ kubeinit_cluster_name }}-nexus:latest
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Remove the buildah container
+  ansible.builtin.command: buildah rm {{ kubeinit_cluster_name }}-nexus
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create a podman volume for nexus data
   containers.podman.podman_volume:
-    name: "kubeinit-nexus-data"
+    name: "{{ kubeinit_cluster_name }}-nexus-data"
     state: present
     recreate: yes
 
 - name: Set nexus as owner of the volume root
   containers.podman.podman_container:
     name: "{{ kubeinit_nexus_service_name }}-set-owner"
-    image: kubeinit/kubeinit-nexus:latest
+    image: kubeinit/{{ kubeinit_cluster_name }}-nexus:latest
     state: started
     detach: no
     remove: yes
     user: root
     command: chown nexus:nexus /mnt
     volumes:
-      - "kubeinit-nexus-data:/mnt"
+      - "{{ kubeinit_cluster_name }}-nexus-data:/mnt"
 
 - name: Copy data into nexus-data volume
   containers.podman.podman_container:
     name: "{{ kubeinit_nexus_service_name }}-copy-data"
-    image: kubeinit/kubeinit-nexus:latest
+    image: kubeinit/{{ kubeinit_cluster_name }}-nexus:latest
     state: started
     detach: no
     remove: yes
     command: cp -pr /mnt/etc /nexus-data/
     volumes:
-      - "kubeinit-nexus-data:/nexus-data"
+      - "{{ kubeinit_cluster_name }}-nexus-data:/nexus-data"
       - "{{ kubeinit_nexus_directory_data }}:/mnt"
 
 - name: Create a podman container to serve nexus
   containers.podman.podman_container:
     name: "{{ kubeinit_nexus_service_name }}"
-    image: kubeinit/kubeinit-nexus:latest
+    image: kubeinit/{{ kubeinit_cluster_name }}-nexus:latest
     pod: "{{ kubeinit_deployment_pod_name }}"
     state: stopped
     volumes:
-      - "kubeinit-nexus-data:/nexus-data"
+      - "{{ kubeinit_cluster_name }}-nexus-data:/nexus-data"
       - "{{ kubeinit_services_data_volume }}:/var/kubeinit"
   register: _result_container_info
 
@@ -180,7 +190,7 @@
 
 - name: Copy out admin password
   ansible.builtin.command: |
-    podman cp kubeinit-nexus:/nexus-data/admin.password "{{ kubeinit_nexus_directory_data }}/admin.password"
+    podman cp {{ kubeinit_cluster_name }}-nexus:/nexus-data/admin.password "{{ kubeinit_nexus_directory_data }}/admin.password"
   register: _result
   changed_when: "_result.rc == 0"
 

--- a/kubeinit/roles/kubeinit_okd/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/main.yml
@@ -21,10 +21,9 @@
     public: yes
   loop: "{{ groups['all_extra_nodes'] }}"
   loop_control:
-    loop_var: cluster_role_item
+    loop_var: kubeinit_deployment_node_name
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
+    kubeinit_deployment_delegate: "{{ hostvars[kubeinit_deployment_node_name].target }}"
     kubeinit_ignition_name: bootstrap
 
 - name: Deploy the cluster controller nodes
@@ -34,10 +33,9 @@
     public: yes
   loop: "{{ groups['all_controller_nodes'] }}"
   loop_control:
-    loop_var: cluster_role_item
+    loop_var: kubeinit_deployment_node_name
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
+    kubeinit_deployment_delegate: "{{ hostvars[kubeinit_deployment_node_name].target }}"
     kubeinit_ignition_name: master
 
 - name: Verify that controller nodes are ok
@@ -107,7 +105,7 @@
 
 - name: Remove bootstrap node from haproxy config
   ansible.builtin.command: |
-    podman --remote --connection {{ kubeinit_haproxy_service_node }} exec {{ kubeinit_haproxy_service_name }} sed -i '/bootstrap/s/^/#/' /usr/local/etc/haproxy/haproxy.cfg
+    podman --remote --connection {{ hostvars[kubeinit_haproxy_service_node].target }} exec {{ kubeinit_haproxy_service_name }} sed -i '/bootstrap/s/^/#/' /usr/local/etc/haproxy/haproxy.cfg
   register: _result
   changed_when: "_result.rc == 0"
   delegate_to: localhost
@@ -150,10 +148,9 @@
     public: yes
   loop: "{{ groups['all_compute_nodes'] | default([]) }}"
   loop_control:
-    loop_var: cluster_role_item
+    loop_var: kubeinit_deployment_node_name
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
+    kubeinit_deployment_delegate: "{{ hostvars[kubeinit_deployment_node_name].target }}"
     kubeinit_ignition_name: worker
 
 - name: Complete the cluster deployment on the provision service node

--- a/kubeinit/roles/kubeinit_prepare/tasks/cleanup_hypervisors.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/cleanup_hypervisors.yml
@@ -44,18 +44,28 @@
   register: _result_connections
   changed_when: "_result_connections.rc == 0"
 
-- name: Remove any existing remote system connection definition for bastion hypervisor
-  ansible.builtin.command: |
-    podman --remote system connection remove {{ item }}
-  loop: "{{ _result_connections.stdout_lines | list }}"
-  register: _result
-  changed_when: "_result.rc == 0"
+# - name: Remove any existing remote system connection definition for bastion hypervisor
+#   ansible.builtin.command: |
+#     podman --remote system connection remove {{ item }}
+#   loop: "{{ _result_connections.stdout_lines | list }}"
+#   register: _result
+#   changed_when: "_result.rc == 0"
 
 - name: Reset local ssh keys
   ansible.builtin.known_hosts:
     name: "{{ item[1] }}"
     state: absent
   loop: "{{ kubeinit_cluster_hostvars.node_aliases }}"
+
+- name: Reset ssh keys in hypervisors
+  ansible.builtin.known_hosts:
+    name: "{{ node_alias }}"
+    state: absent
+  loop: "{{ groups['all_hosts'] | product(kubeinit_cluster_hostvars.node_aliases | flatten | unique) }}"
+  vars:
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    node_alias: "{{ item[1] }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"
 
 - name: Remove any existing ssh tunnels on bastion host
   ansible.builtin.shell: |
@@ -99,7 +109,7 @@
     loop_var: orphaned_pod
   vars:
     service_node: "{{ orphaned_pod[0] }}"
-    pod_name: "{{ orphaned_pod[0] }}-pod"
+    pod_name: "{{ hostvars[orphaned_pod[0]].guest_name }}-pod"
     pod: "{{ orphaned_pod[1] }}"
   when: pod_name == pod.Name
 
@@ -174,11 +184,9 @@
   register: _result_stop_service
   failed_when: _result_stop_service is not defined
   loop: "{{ groups['all_hosts'] | product(kubeinit_cluster_hostvars.services) }}"
-  loop_control:
-    loop_var: cluster_role_item
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    service_name: "{{ kubeinit_cluster_name }}-{{ cluster_role_item[1] }}"
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    service_name: "{{ kubeinit_cluster_name }}-{{ item[1] }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
 
 - name: Remove any previous services podman pods
@@ -276,24 +284,20 @@
     executable: /bin/bash
   loop: "{{ groups['all_hosts'] }}"
   loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    loop_var: kubeinit_deployment_node_name
   register: _result
   changed_when: "_result.rc == 0"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
 
-- name: Prune all podman resources
+- name: Prune container images created for the cluster
   ansible.builtin.shell: |
     set -eo pipefail
-    podman system prune -a -f || true
+    podman image prune --filter label=kubeinit-cluster-name={{ kubeinit_cluster_name }} --all --force || true
   args:
     executable: /bin/bash
   loop: "{{ groups['all_hosts'] }}"
   loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    loop_var: kubeinit_deployment_node_name
   register: _result
   changed_when: "_result.rc == 0"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
@@ -305,11 +309,9 @@
   args:
     executable: /bin/bash
   loop: "{{ groups['all_hosts'] | product(groups['all_service_nodes']) }}"
-  loop_control:
-    loop_var: cluster_role_item
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    ovs_veth_devname: "veth0-{{ hostvars[cluster_role_item[1]].ansible_host | ansible.netcommon.ip4_hex }}"
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    ovs_veth_devname: "veth0-{{ hostvars[item[1]].ansible_host | ansible.netcommon.ip4_hex }}"
   register: _result
   changed_when: "_result.rc == 0"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
@@ -321,11 +323,9 @@
   args:
     executable: /bin/bash
   loop: "{{ groups['all_hosts'] | product(groups['all_service_nodes']) }}"
-  loop_control:
-    loop_var: cluster_role_item
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item[0] }}"
-    ovs_veth_devname: "veth0-{{ hostvars[cluster_role_item[1]].ansible_host | ansible.netcommon.ip4_hex }}"
+    kubeinit_deployment_node_name: "{{ item[0] }}"
+    ovs_veth_devname: "veth0-{{ hostvars[item[1]].ansible_host | ansible.netcommon.ip4_hex }}"
   register: _result
   changed_when: "_result.rc == 0"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
@@ -347,7 +347,7 @@
         kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-cleanup-hypervisors' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play

--- a/kubeinit/roles/kubeinit_prepare/tasks/deploy_cluster.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/deploy_cluster.yml
@@ -48,7 +48,7 @@
         kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-deploy-cluster' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play

--- a/kubeinit/roles/kubeinit_prepare/tasks/gather_host_facts.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/gather_host_facts.yml
@@ -103,6 +103,24 @@
         podman_installed: "{{ podman_state != '' }}"
         podman_active: "{{ true if podman_state == 'running' else false }}"
 
+    - name: Set ovs_vswitchd_state to unknown
+      ansible.builtin.set_fact:
+        ovs_vswitchd_state: 'unknown'
+
+    - name: Set ovs_vswitchd_state when ovs-vswitchd is defined
+      ansible.builtin.set_fact:
+        ovs_vswitchd_state: "{{ _result_services.ansible_facts.services['ovs-vswitchd'].state }}"
+      when: _result_services.ansible_facts.services['ovs-vswitchd'] is defined
+
+    - name: Set ovs_vswitchd_state when ovs-vswitchd.service is defined
+      ansible.builtin.set_fact:
+        ovs_vswitchd_state: "{{ _result_services.ansible_facts.services['ovs-vswitchd.service'].state }}"
+      when: _result_services.ansible_facts.services['ovs-vswitchd.service'] is defined
+
+    - name: Set ovs_vswitchd_active
+      ansible.builtin.set_fact:
+        ovs_vswitchd_active: "{{ true if ovs_vswitchd_state == 'running' else false }}"
+
     - name: Clear libvirtd_state
       ansible.builtin.set_fact:
         libvirtd_state: ''
@@ -161,6 +179,7 @@
         firewalld_is_active: "{{ firewalld_active }}"
         podman_is_installed: "{{ podman_installed }}"
         podman_is_active: "{{ podman_active }}"
+        ovs_is_active: "{{ ovs_vswitchd_active }}"
         libvirt_nets: "{{ _result_nets.list_nets | default([]) }}"
         libvirt_vms: "{{ _result_vms.list_vms | default([]) }}"
         public_key: "{{ _result_keypair.public_key | default(omit) }}"

--- a/kubeinit/roles/kubeinit_prepare/tasks/gather_kubeinit_facts.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/gather_kubeinit_facts.yml
@@ -215,9 +215,7 @@
   ansible.builtin.include_tasks: gather_host_facts.yml
   loop: "{{ hostvars[kubeinit_cluster_facts_name].hypervisors | union(['localhost']) }}"
   loop_control:
-    loop_var: cluster_role_item
-  vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
+    loop_var: kubeinit_deployment_node_name
 
 - name: Determine the hypervisor target for all inventory nodes
   ansible.builtin.set_fact:
@@ -317,7 +315,7 @@
         tasks_completed: "{{ ['task-gather-facts'] }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-gather-facts' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play

--- a/kubeinit/roles/kubeinit_prepare/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/main.yml
@@ -27,7 +27,7 @@
         tasks_completed: "{{ hostvars[kubeinit_cluster_facts_name].tasks_completed | union(['task-prepare-hypervisors']) }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-prepare-hypervisors' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play
@@ -179,7 +179,7 @@
         kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-prepare-environment' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play

--- a/kubeinit/roles/kubeinit_prepare/tasks/post_deployment.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/post_deployment.yml
@@ -49,7 +49,7 @@
         kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-post-deployment' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_cluster.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_cluster.yml
@@ -49,7 +49,7 @@
         kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-prepare-cluster' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_groups.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_groups.yml
@@ -64,10 +64,14 @@
     all_cluster_hypervisors: "{{ all_cluster_hypervisors | default([]) | union([hostvars[item].target]) }}"
   loop: "{{ groups['all_cluster_nodes'] + (groups['all_extra_nodes'] | default([])) }}"
 
-- name: Set all cluster hypervisors fact
-  ansible.builtin.add_host:
-    name: "{{ kubeinit_cluster_facts_name }}"
-    hypervisors: "{{ all_cluster_hypervisors }}"
+- name: Show the before and after values of the hypervisors fact
+  ansible.builtin.debug: msg="{{ hostvars[kubeinit_cluster_facts_name].hypervisors }} ==> {{ all_cluster_hypervisors }}"
+
+# TODO: check later to see if this would be a useful optimization
+# - name: Set all cluster hypervisors fact
+#   ansible.builtin.add_host:
+#     name: "{{ kubeinit_cluster_facts_name }}"
+#     hypervisors: "{{ all_cluster_hypervisors }}"
 
 - name: Add all service nodes to the all_service_nodes group
   ansible.builtin.add_host:

--- a/kubeinit/roles/kubeinit_prepare/tasks/prepare_podman.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/prepare_podman.yml
@@ -15,7 +15,7 @@
 # under the License.
 
 #
-# We should already have podman in all the distros we use.
+# We should already have podman in all the distro repos we use.
 #
 
 - name: Install common requirements

--- a/kubeinit/roles/kubeinit_registry/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/main.yml
@@ -20,24 +20,34 @@
     name: "buildah"
 
 - name: Create a new working container image
-  ansible.builtin.command: buildah from --name buildah-registry docker.io/library/registry:2
+  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-registry docker.io/library/registry:2
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Update the container
-  ansible.builtin.command: buildah run buildah-registry -- apk upgrade
+  ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-registry -- apk upgrade
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Set kubeinit-cluster-name label
+  ansible.builtin.command: buildah config --label kubeinit-cluster-name={{ kubeinit_cluster_name }} {{ kubeinit_cluster_name }}-registry
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Commit the container image
-  ansible.builtin.command: buildah commit buildah-registry kubeinit/kubeinit-registry:latest
+  ansible.builtin.command: buildah commit {{ kubeinit_cluster_name }}-registry kubeinit/{{ kubeinit_cluster_name }}-registry:latest
+  register: _result
+  changed_when: "_result.rc == 0"
+
+- name: Remove the buildah container
+  ansible.builtin.command: buildah rm {{ kubeinit_cluster_name }}-registry
   register: _result
   changed_when: "_result.rc == 0"
 
 - name: Create a podman container to serve the registry
   containers.podman.podman_container:
     name: "{{ kubeinit_registry_service_name }}"
-    image: kubeinit/kubeinit-registry:latest
+    image: kubeinit/{{ kubeinit_cluster_name }}-registry:latest
     pod: "{{ kubeinit_deployment_pod_name }}"
     init: true
     state: stopped
@@ -59,10 +69,10 @@
 - name: Copy kubeinit registry secrets into registry container
   ansible.builtin.shell: |
     set -eo pipefail
-    podman --remote --connection {{ kubeinit_registry_service_node }} cp {{ kubeinit_registry_service_name }}:{{ kubeinit_registry_directory_auth }} - | \
-      podman --remote --connection {{ kubeinit_registry_service_node }} cp - "{{ kubeinit_registry_service_name }}:/"
-    podman --remote --connection {{ kubeinit_registry_service_node }} cp {{ kubeinit_registry_service_name }}:{{ kubeinit_registry_directory_cert }} - | \
-      podman --remote --connection {{ kubeinit_registry_service_node }} cp - "{{ kubeinit_registry_service_name }}:/"
+    podman --remote --connection {{ hostvars[kubeinit_registry_service_node].target }} cp {{ kubeinit_registry_service_name }}:{{ kubeinit_registry_directory_auth }} - | \
+      podman --remote --connection {{ hostvars[kubeinit_registry_service_node].target }} cp - "{{ kubeinit_registry_service_name }}:/"
+    podman --remote --connection {{ hostvars[kubeinit_registry_service_node].target }} cp {{ kubeinit_registry_service_name }}:{{ kubeinit_registry_directory_cert }} - | \
+      podman --remote --connection {{ hostvars[kubeinit_registry_service_node].target }} cp - "{{ kubeinit_registry_service_name }}:/"
   args:
     executable: /bin/bash
   register: _result

--- a/kubeinit/roles/kubeinit_services/tasks/00_create_service_pod.yml
+++ b/kubeinit/roles/kubeinit_services/tasks/00_create_service_pod.yml
@@ -98,7 +98,7 @@
 
 - name: Add remote system connection definition for bastion hypervisor
   ansible.builtin.command: |
-    podman --remote system connection add "{{ kubeinit_deployment_node_name }}" --identity "~/.ssh/{{ kubeinit_cluster_name }}_id_rsa" "ssh://{{ kubeinit_service_user }}@{{ kubeinit_bastion_host_address }}:{{ podman_remote_ssh_port }}{{ _result_systemd_runtime_path.stdout }}/podman/podman.sock"
+    podman --remote system connection add "{{ hostvars[kubeinit_deployment_node_name].target }}" --identity "~/.ssh/{{ kubeinit_cluster_name }}_id_rsa" "ssh://{{ kubeinit_service_user }}@{{ kubeinit_bastion_host_address }}:{{ podman_remote_ssh_port }}{{ _result_systemd_runtime_path.stdout }}/podman/podman.sock"
   register: _result
   changed_when: "_result.rc == 0"
   delegate_to: localhost
@@ -115,6 +115,7 @@
     - name: Create a podman network for the service containers
       containers.podman.podman_network:
         name: "{{ kubeinit_deployment_bridge_name }}"
+        disable_dns: true
         opt:
           mtu: 1442
           vlan: 0

--- a/kubeinit/roles/kubeinit_services/tasks/create_provision_container.yml
+++ b/kubeinit/roles/kubeinit_services/tasks/create_provision_container.yml
@@ -25,9 +25,9 @@
     - name: Remove any old buildah container
       ansible.builtin.shell: |
         set -eo pipefail
-        if [ "$(buildah ls --filter 'name=buildah-provision' --format {% raw %}'{{ .ContainerName }}'{% endraw %})" != "" ]
+        if [ "$(buildah ls --filter 'name={{ kubeinit_cluster_name }}-provision' --format {% raw %}'{{ .ContainerName }}'{% endraw %})" != "" ]
         then
-          buildah rm buildah-provision
+          buildah rm {{ kubeinit_cluster_name }}-provision
         fi
       args:
         executable: /bin/bash
@@ -37,15 +37,15 @@
     - name: Setup CentOS container image
       block:
         - name: Create a new working container image (CentOS)
-          ansible.builtin.command: buildah from --name buildah-provision quay.io/centos/centos:stream8
+          ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-provision quay.io/centos/centos:stream8
           register: _result
           changed_when: "_result.rc == 0"
         - name: Update the container
-          ansible.builtin.command: buildah run buildah-provision -- dnf update -q -y
+          ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-provision -- dnf update -q -y
           register: _result
           changed_when: "_result.rc == 0"
         - name: Install commands and services we will need
-          ansible.builtin.command: buildah run buildah-provision -- dnf install -q -y systemd openssh openssh-server openssh-clients procps iproute iputils net-tools python3 python3-pip jq
+          ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-provision -- dnf install -q -y systemd openssh openssh-server openssh-clients procps iproute iputils net-tools python3 python3-pip jq
           register: _result
           changed_when: "_result.rc == 0"
       when: kubeinit_deployment_os == 'centos'
@@ -53,19 +53,19 @@
     - name: Setup Debian container image
       block:
         - name: Create a new working container image
-          ansible.builtin.command: buildah from --name buildah-provision docker.io/debian:{{ kubeinit_libvirt_debian_release }}
+          ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-provision docker.io/debian:{{ kubeinit_libvirt_debian_release }}
           register: _result
           changed_when: "_result.rc == 0"
         - name: Update the container
-          ansible.builtin.command: buildah run buildah-provision -- apt-get update -q -y
+          ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-provision -- apt-get update -q -y
           register: _result
           changed_when: "_result.rc == 0"
         - name: Install commands and services we will need
-          ansible.builtin.command: buildah run buildah-provision -- env DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -q -y systemd openssh-server openssh-client procps iproute2 iputils-ping net-tools python3 python3-pip jq curl
+          ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-provision -- env DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -q -y systemd openssh-server openssh-client procps iproute2 iputils-ping net-tools python3 python3-pip jq curl
           register: _result
           changed_when: "_result.rc == 0"
         - name: Missing privilege separation directory
-          ansible.builtin.command: buildah run buildah-provision -- mkdir -p /run/sshd
+          ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-provision -- mkdir -p /run/sshd
           register: _result
           changed_when: "_result.rc == 0"
       when: kubeinit_deployment_os == 'debian'
@@ -73,45 +73,55 @@
     - name: Setup Ubuntu container image
       block:
         - name: Create a new working container image
-          ansible.builtin.command: buildah from --name buildah-provision docker.io/ubuntu:{{ 'focal' if (kubeinit_cluster_distro == 'cdk') else 'hirsute' }}
+          ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-provision docker.io/ubuntu:{{ 'focal' if (kubeinit_cluster_distro == 'cdk') else 'hirsute' }}
           register: _result
           changed_when: "_result.rc == 0"
         - name: Update the container
-          ansible.builtin.command: buildah run buildah-provision -- apt-get update -q -y
+          ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-provision -- apt-get update -q -y
           register: _result
           changed_when: "_result.rc == 0"
         - name: Install commands and services we will need
-          ansible.builtin.command: buildah run buildah-provision -- env DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -q -y systemd openssh-server openssh-client procps iproute2 iputils-ping net-tools python3 python3-pip jq curl
+          ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-provision -- env DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -q -y systemd openssh-server openssh-client procps iproute2 iputils-ping net-tools python3 python3-pip jq curl
           register: _result
           changed_when: "_result.rc == 0"
         - name: Create folder normally done by service ssh start
-          ansible.builtin.command: buildah run buildah-provision -- mkdir /run/sshd
+          ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-provision -- mkdir /run/sshd
           register: _result
           changed_when: "_result.rc == 0"
       when: kubeinit_deployment_os == 'ubuntu'
 
     - name: Set working directory inside container
-      ansible.builtin.command: buildah config --workingdir {{ kubeinit_service_user_dir }} buildah-provision
+      ansible.builtin.command: buildah config --workingdir {{ kubeinit_service_user_dir }} {{ kubeinit_cluster_name }}-provision
       register: _result
       changed_when: "_result.rc == 0"
 
     - name: Generate system ssh keys
-      ansible.builtin.command: buildah run buildah-provision -- bash -c "(cd /etc/ssh; ssh-keygen -A)"
+      ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-provision -- bash -c "(cd /etc/ssh; ssh-keygen -A)"
       register: _result
       changed_when: "_result.rc == 0"
 
     - name: Clear cmd
-      ansible.builtin.command: buildah config --cmd '' buildah-provision
+      ansible.builtin.command: buildah config --cmd '' {{ kubeinit_cluster_name }}-provision
       register: _result
       changed_when: "_result.rc == 0"
 
     - name: Set entrypoint
-      ansible.builtin.command: buildah config --entrypoint '["/sbin/init"]' buildah-provision
+      ansible.builtin.command: buildah config --entrypoint '["/sbin/init"]' {{ kubeinit_cluster_name }}-provision
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Set kubeinit-cluster-name label
+      ansible.builtin.command: buildah config --label kubeinit-cluster-name={{ kubeinit_cluster_name }} {{ kubeinit_cluster_name }}-provision
       register: _result
       changed_when: "_result.rc == 0"
 
     - name: Commit the image
-      ansible.builtin.command: buildah commit buildah-provision kubeinit/kubeinit-provision:latest
+      ansible.builtin.command: buildah commit {{ kubeinit_cluster_name }}-provision kubeinit/{{ kubeinit_cluster_name }}-provision:latest
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Remove the buildah container
+      ansible.builtin.command: buildah rm {{ kubeinit_cluster_name }}-provision
       register: _result
       changed_when: "_result.rc == 0"
 
@@ -123,7 +133,7 @@
     - name: Create podman provision container
       containers.podman.podman_container:
         name: "{{ kubeinit_provision_service_name }}"
-        image: kubeinit/kubeinit-provision:latest
+        image: kubeinit/{{ kubeinit_cluster_name }}-provision:latest
         pod: "{{ kubeinit_deployment_pod_name }}"
         state: stopped
         cap_add:
@@ -149,7 +159,7 @@
     hostname: "{{ kubeinit_provision_service_name }}"
     ansible_connection: containers.podman.podman
     ansible_python_interpreter: /usr/bin/python3
-    ansible_podman_extra_args: --remote --connection "{{ kubeinit_deployment_node_name }}"
+    ansible_podman_extra_args: --remote --connection "{{ hostvars[kubeinit_deployment_node_name].target }}"
 
 - name: Disable pipelining while using podman connector
   block:

--- a/kubeinit/roles/kubeinit_services/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_services/tasks/main.yml
@@ -36,12 +36,11 @@
   ansible.builtin.include_tasks: 00_create_service_pod.yml
   loop: "{{ groups['all_service_nodes'] }}"
   loop_control:
-    loop_var: cluster_role_item
+    loop_var: kubeinit_deployment_node_name
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    kubeinit_deployment_bridge_name: "{{ hostvars[cluster_role_item].guest_name }}-bridge"
-    kubeinit_deployment_pod_name: "{{ hostvars[cluster_role_item].guest_name }}-pod"
-    kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
+    kubeinit_deployment_bridge_name: "{{ hostvars[kubeinit_deployment_node_name].guest_name }}-bridge"
+    kubeinit_deployment_pod_name: "{{ hostvars[kubeinit_deployment_node_name].guest_name }}-pod"
+    kubeinit_deployment_delegate: "{{ hostvars[kubeinit_deployment_node_name].target }}"
 
 - name: Prepare the credentials we are going to use in the cluster
   ansible.builtin.include_tasks: prepare_credentials.yml
@@ -54,11 +53,10 @@
   ansible.builtin.include_tasks: start_services_containers.yml
   loop: "{{ groups['all_service_nodes'] }}"
   loop_control:
-    loop_var: cluster_role_item
+    loop_var: kubeinit_deployment_node_name
   vars:
-    kubeinit_deployment_node_name: "{{ cluster_role_item }}"
-    kubeinit_deployment_pod_name: "{{ hostvars[cluster_role_item].guest_name }}-pod"
-    kubeinit_deployment_delegate: "{{ hostvars[cluster_role_item].target }}"
+    kubeinit_deployment_pod_name: "{{ hostvars[kubeinit_deployment_node_name].guest_name }}-pod"
+    kubeinit_deployment_delegate: "{{ hostvars[kubeinit_deployment_node_name].target }}"
 
 - block:
     - name: Add task-create-services to tasks_completed
@@ -71,7 +69,7 @@
         kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-create-services' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play

--- a/kubeinit/roles/kubeinit_services/tasks/prepare_credentials.yml
+++ b/kubeinit/roles/kubeinit_services/tasks/prepare_credentials.yml
@@ -17,6 +17,48 @@
 - name: Delegate to the service node target
   block:
 
+    - name: Install buildah if required
+      ansible.builtin.package:
+        state: present
+        name: "buildah"
+
+    - name: Remove any old buildah container
+      ansible.builtin.shell: |
+        set -eo pipefail
+        if [ "$(buildah ls --filter 'name={{ kubeinit_cluster_name }}-credentials' --format {% raw %}'{{ .ContainerName }}'{% endraw %})" != "" ]
+        then
+          buildah rm {{ kubeinit_cluster_name }}-credentials
+        fi
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Create a new working container image
+      ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-credentials quay.io/centos/centos:stream8
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Install commands and services we will need
+      ansible.builtin.command: buildah run {{ kubeinit_cluster_name }}-credentials -- dnf install -q -y procps iproute iputils net-tools bind-utils
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Set kubeinit-cluster-name label
+      ansible.builtin.command: buildah config --label kubeinit-cluster-name={{ kubeinit_cluster_name }} {{ kubeinit_cluster_name }}-credentials
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Commit the image
+      ansible.builtin.command: buildah commit {{ kubeinit_cluster_name }}-credentials kubeinit/{{ kubeinit_cluster_name }}-credentials:latest
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Remove the buildah container
+      ansible.builtin.command: buildah rm {{ kubeinit_cluster_name }}-credentials
+      register: _result
+      changed_when: "_result.rc == 0"
+
     - name: Remove any previous credentials container
       containers.podman.podman_container:
         name: "{{ kubeinit_cluster_name }}-credentials"
@@ -25,7 +67,7 @@
     - name: Create podman credentials container
       containers.podman.podman_container:
         name: "{{ kubeinit_cluster_name }}-credentials"
-        image: quay.io/centos/centos:stream8
+        image: kubeinit/{{ kubeinit_cluster_name }}-credentials:latest
         pod: "{{ kubeinit_deployment_pod_name }}"
         init: true
         cap_add:
@@ -51,7 +93,7 @@
     hostname: "{{ kubeinit_cluster_name }}-credentials"
     ansible_connection: containers.podman.podman
     ansible_python_interpreter: /usr/bin/python3
-    ansible_podman_extra_args: --remote --connection "{{ kubeinit_deployment_node_name }}"
+    ansible_podman_extra_args: --remote --connection "{{ hostvars[kubeinit_deployment_node_name].target }}"
 
 - name: Disable pipelining while using podman connector
   block:

--- a/kubeinit/roles/kubeinit_validations/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_validations/tasks/main.yml
@@ -56,7 +56,7 @@
         kubeinit_cluster_hostvars: "{{ hostvars[kubeinit_cluster_facts_name] }}"
 
     - block:
-        - name: "Stopping after '{{ kubeinit_stop_after_task }}'"
+        - name: Stop after 'task-run-validations' when requested
           ansible.builtin.add_host: name="{{ kubeinit_cluster_facts_name }}" playbook_terminated=true
         - name: End play
           ansible.builtin.meta: end_play


### PR DESCRIPTION
This commit adds support for multiple clusters deployed from the
same inventory.  Most changes are to names of resources that need
to be distinct so that clusters can co-exist.