### PR TITLE
docs: include unicode assets

### DIFF
--- a/docs/src/static/css/custom.css
+++ b/docs/src/static/css/custom.css
@@ -1,5 +1,14 @@
+h1 {
+    font-size: 400%;
+}
+h2 {
+    font-size: 250%;
+}
 h3 {
-    font-size: 90%;
+    font-size: 150%;
+}
+h4 {
+    font-size: 100%;
 }
 
 .wy-nav-content {

--- a/docs/src/static/parsers/xhtml1-symbol.txt
+++ b/docs/src/static/parsers/xhtml1-symbol.txt
@@ -1,0 +1,130 @@
+.. This data file has been placed in the public domain.
+.. Derived from the Unicode character mappings available from
+   <http://www.w3.org/2003/entities/xml/>.
+   Processed by unicode2rstsubs.py, part of Docutils:
+   <http://docutils.sourceforge.net>.
+
+.. |alefsym|  unicode:: U+02135 .. ALEF SYMBOL
+.. |Alpha|    unicode:: U+00391 .. GREEK CAPITAL LETTER ALPHA
+.. |alpha|    unicode:: U+003B1 .. GREEK SMALL LETTER ALPHA
+.. |and|      unicode:: U+02227 .. LOGICAL AND
+.. |ang|      unicode:: U+02220 .. ANGLE
+.. |asymp|    unicode:: U+02248 .. ALMOST EQUAL TO
+.. |Beta|     unicode:: U+00392 .. GREEK CAPITAL LETTER BETA
+.. |beta|     unicode:: U+003B2 .. GREEK SMALL LETTER BETA
+.. |bull|     unicode:: U+02022 .. BULLET
+.. |cap|      unicode:: U+02229 .. INTERSECTION
+.. |Chi|      unicode:: U+003A7 .. GREEK CAPITAL LETTER CHI
+.. |chi|      unicode:: U+003C7 .. GREEK SMALL LETTER CHI
+.. |clubs|    unicode:: U+02663 .. BLACK CLUB SUIT
+.. |cong|     unicode:: U+02245 .. APPROXIMATELY EQUAL TO
+.. |crarr|    unicode:: U+021B5 .. DOWNWARDS ARROW WITH CORNER LEFTWARDS
+.. |cup|      unicode:: U+0222A .. UNION
+.. |dArr|     unicode:: U+021D3 .. DOWNWARDS DOUBLE ARROW
+.. |darr|     unicode:: U+02193 .. DOWNWARDS ARROW
+.. |Delta|    unicode:: U+00394 .. GREEK CAPITAL LETTER DELTA
+.. |delta|    unicode:: U+003B4 .. GREEK SMALL LETTER DELTA
+.. |diams|    unicode:: U+02666 .. BLACK DIAMOND SUIT
+.. |empty|    unicode:: U+02205 .. EMPTY SET
+.. |Epsilon|  unicode:: U+00395 .. GREEK CAPITAL LETTER EPSILON
+.. |epsilon|  unicode:: U+003B5 .. GREEK SMALL LETTER EPSILON
+.. |equiv|    unicode:: U+02261 .. IDENTICAL TO
+.. |Eta|      unicode:: U+00397 .. GREEK CAPITAL LETTER ETA
+.. |eta|      unicode:: U+003B7 .. GREEK SMALL LETTER ETA
+.. |exist|    unicode:: U+02203 .. THERE EXISTS
+.. |fnof|     unicode:: U+00192 .. LATIN SMALL LETTER F WITH HOOK
+.. |forall|   unicode:: U+02200 .. FOR ALL
+.. |frasl|    unicode:: U+02044 .. FRACTION SLASH
+.. |Gamma|    unicode:: U+00393 .. GREEK CAPITAL LETTER GAMMA
+.. |gamma|    unicode:: U+003B3 .. GREEK SMALL LETTER GAMMA
+.. |ge|       unicode:: U+02265 .. GREATER-THAN OR EQUAL TO
+.. |hArr|     unicode:: U+021D4 .. LEFT RIGHT DOUBLE ARROW
+.. |harr|     unicode:: U+02194 .. LEFT RIGHT ARROW
+.. |hearts|   unicode:: U+02665 .. BLACK HEART SUIT
+.. |hellip|   unicode:: U+02026 .. HORIZONTAL ELLIPSIS
+.. |image|    unicode:: U+02111 .. BLACK-LETTER CAPITAL I
+.. |infin|    unicode:: U+0221E .. INFINITY
+.. |int|      unicode:: U+0222B .. INTEGRAL
+.. |Iota|     unicode:: U+00399 .. GREEK CAPITAL LETTER IOTA
+.. |iota|     unicode:: U+003B9 .. GREEK SMALL LETTER IOTA
+.. |isin|     unicode:: U+02208 .. ELEMENT OF
+.. |Kappa|    unicode:: U+0039A .. GREEK CAPITAL LETTER KAPPA
+.. |kappa|    unicode:: U+003BA .. GREEK SMALL LETTER KAPPA
+.. |Lambda|   unicode:: U+0039B .. GREEK CAPITAL LETTER LAMDA
+.. |lambda|   unicode:: U+003BB .. GREEK SMALL LETTER LAMDA
+.. |lang|     unicode:: U+02329 .. LEFT-POINTING ANGLE BRACKET
+.. |lArr|     unicode:: U+021D0 .. LEFTWARDS DOUBLE ARROW
+.. |larr|     unicode:: U+02190 .. LEFTWARDS ARROW
+.. |lceil|    unicode:: U+02308 .. LEFT CEILING
+.. |le|       unicode:: U+02264 .. LESS-THAN OR EQUAL TO
+.. |lfloor|   unicode:: U+0230A .. LEFT FLOOR
+.. |lowast|   unicode:: U+02217 .. ASTERISK OPERATOR
+.. |loz|      unicode:: U+025CA .. LOZENGE
+.. |minus|    unicode:: U+02212 .. MINUS SIGN
+.. |Mu|       unicode:: U+0039C .. GREEK CAPITAL LETTER MU
+.. |mu|       unicode:: U+003BC .. GREEK SMALL LETTER MU
+.. |nabla|    unicode:: U+02207 .. NABLA
+.. |ne|       unicode:: U+02260 .. NOT EQUAL TO
+.. |ni|       unicode:: U+0220B .. CONTAINS AS MEMBER
+.. |notin|    unicode:: U+02209 .. NOT AN ELEMENT OF
+.. |nsub|     unicode:: U+02284 .. NOT A SUBSET OF
+.. |Nu|       unicode:: U+0039D .. GREEK CAPITAL LETTER NU
+.. |nu|       unicode:: U+003BD .. GREEK SMALL LETTER NU
+.. |oline|    unicode:: U+0203E .. OVERLINE
+.. |Omega|    unicode:: U+003A9 .. GREEK CAPITAL LETTER OMEGA
+.. |omega|    unicode:: U+003C9 .. GREEK SMALL LETTER OMEGA
+.. |Omicron|  unicode:: U+0039F .. GREEK CAPITAL LETTER OMICRON
+.. |omicron|  unicode:: U+003BF .. GREEK SMALL LETTER OMICRON
+.. |oplus|    unicode:: U+02295 .. CIRCLED PLUS
+.. |or|       unicode:: U+02228 .. LOGICAL OR
+.. |otimes|   unicode:: U+02297 .. CIRCLED TIMES
+.. |part|     unicode:: U+02202 .. PARTIAL DIFFERENTIAL
+.. |perp|     unicode:: U+022A5 .. UP TACK
+.. |Phi|      unicode:: U+003A6 .. GREEK CAPITAL LETTER PHI
+.. |phi|      unicode:: U+003D5 .. GREEK PHI SYMBOL
+.. |Pi|       unicode:: U+003A0 .. GREEK CAPITAL LETTER PI
+.. |pi|       unicode:: U+003C0 .. GREEK SMALL LETTER PI
+.. |piv|      unicode:: U+003D6 .. GREEK PI SYMBOL
+.. |Prime|    unicode:: U+02033 .. DOUBLE PRIME
+.. |prime|    unicode:: U+02032 .. PRIME
+.. |prod|     unicode:: U+0220F .. N-ARY PRODUCT
+.. |prop|     unicode:: U+0221D .. PROPORTIONAL TO
+.. |Psi|      unicode:: U+003A8 .. GREEK CAPITAL LETTER PSI
+.. |psi|      unicode:: U+003C8 .. GREEK SMALL LETTER PSI
+.. |radic|    unicode:: U+0221A .. SQUARE ROOT
+.. |rang|     unicode:: U+0232A .. RIGHT-POINTING ANGLE BRACKET
+.. |rArr|     unicode:: U+021D2 .. RIGHTWARDS DOUBLE ARROW
+.. |rarr|     unicode:: U+02192 .. RIGHTWARDS ARROW
+.. |rceil|    unicode:: U+02309 .. RIGHT CEILING
+.. |real|     unicode:: U+0211C .. BLACK-LETTER CAPITAL R
+.. |rfloor|   unicode:: U+0230B .. RIGHT FLOOR
+.. |Rho|      unicode:: U+003A1 .. GREEK CAPITAL LETTER RHO
+.. |rho|      unicode:: U+003C1 .. GREEK SMALL LETTER RHO
+.. |sdot|     unicode:: U+022C5 .. DOT OPERATOR
+.. |Sigma|    unicode:: U+003A3 .. GREEK CAPITAL LETTER SIGMA
+.. |sigma|    unicode:: U+003C3 .. GREEK SMALL LETTER SIGMA
+.. |sigmaf|   unicode:: U+003C2 .. GREEK SMALL LETTER FINAL SIGMA
+.. |sim|      unicode:: U+0223C .. TILDE OPERATOR
+.. |spades|   unicode:: U+02660 .. BLACK SPADE SUIT
+.. |sub|      unicode:: U+02282 .. SUBSET OF
+.. |sube|     unicode:: U+02286 .. SUBSET OF OR EQUAL TO
+.. |sum|      unicode:: U+02211 .. N-ARY SUMMATION
+.. |sup|      unicode:: U+02283 .. SUPERSET OF
+.. |supe|     unicode:: U+02287 .. SUPERSET OF OR EQUAL TO
+.. |Tau|      unicode:: U+003A4 .. GREEK CAPITAL LETTER TAU
+.. |tau|      unicode:: U+003C4 .. GREEK SMALL LETTER TAU
+.. |there4|   unicode:: U+02234 .. THEREFORE
+.. |Theta|    unicode:: U+00398 .. GREEK CAPITAL LETTER THETA
+.. |theta|    unicode:: U+003B8 .. GREEK SMALL LETTER THETA
+.. |thetasym| unicode:: U+003D1 .. GREEK THETA SYMBOL
+.. |trade|    unicode:: U+02122 .. TRADE MARK SIGN
+.. |uArr|     unicode:: U+021D1 .. UPWARDS DOUBLE ARROW
+.. |uarr|     unicode:: U+02191 .. UPWARDS ARROW
+.. |upsih|    unicode:: U+003D2 .. GREEK UPSILON WITH HOOK SYMBOL
+.. |Upsilon|  unicode:: U+003A5 .. GREEK CAPITAL LETTER UPSILON
+.. |upsilon|  unicode:: U+003C5 .. GREEK SMALL LETTER UPSILON
+.. |weierp|   unicode:: U+02118 .. SCRIPT CAPITAL P
+.. |Xi|       unicode:: U+0039E .. GREEK CAPITAL LETTER XI
+.. |xi|       unicode:: U+003BE .. GREEK SMALL LETTER XI
+.. |Zeta|     unicode:: U+00396 .. GREEK CAPITAL LETTER ZETA
+.. |zeta|     unicode:: U+003B6 .. GREEK SMALL LETTER ZETA

--- a/docs/src/usage.rst
+++ b/docs/src/usage.rst
@@ -120,8 +120,8 @@ the hypervisor's IP address. Also when running the
 deployment as a user different than root, the
 keys needs to be also updated.
 
-Running from the GIT repository
-<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+|bull| Running from the GIT repository
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
@@ -138,8 +138,8 @@ Running from the GIT repository
             -i ./kubeinit/inventory \
             ./kubeinit/playbook.yml
 
-Running from a release
-<<<<<<<<<<<<<<<<<<<<<<
+|bull| Running from a release
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
@@ -158,8 +158,8 @@ Running from a release
 Connecting to the cluster
 -------------------------
 
-Accessing the cluster resources internally
-<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+|bull| Accessing the cluster resources internally
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once the deployment is finished the machine used
 for provisioning the cluster have access to both
@@ -197,8 +197,8 @@ For instance:
     .kube/config
 
 
-Accessing the cluster resources externally
-<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
+|bull| Accessing the cluster resources externally
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When the services deployment is executed
 one of the tasks in the kubeinit_bind role
@@ -245,3 +245,9 @@ In this case the deployment will stop just after cleaning the
 hypervisors resources. If its required to remove all the guests
 in the hypervisors its also possible to add the following variable
 `-e kubeinit_libvirt_destroy_all_guests=True`
+
+.. We define some macros to add symbols when required to the
+   docs pages, this is fetched from Docutils
+   https://docutils.sourceforge.io/docutils/parsers/rst/include/
+
+.. include:: static/parsers/xhtml1-symbol.txt


### PR DESCRIPTION
This commit includes some unicode helpers
to add symbols to the docs when they are needed.