### PR TITLE
docs: include extra symbols

### DIFF
--- a/docs/src/static/css/custom.css
+++ b/docs/src/static/css/custom.css
@@ -1,14 +1,24 @@
 h1 {
-    font-size: 400%;
+    font-size: 300%;
 }
 h2 {
-    font-size: 250%;
+    font-size: 200%;
+    font-weight: 100;
 }
 h3 {
     font-size: 150%;
+    font-weight: 100;
 }
 h4 {
     font-size: 100%;
+    font-weight: 1000;
+}
+
+h4:before {
+  content: '■ ';
+    position: relative;
+    bottom: .1em;
+    color: #000;
 }
 
 .wy-nav-content {

--- a/docs/src/static/parsers/xhtml1-lat1.txt
+++ b/docs/src/static/parsers/xhtml1-lat1.txt
@@ -1,0 +1,102 @@
+.. This data file has been placed in the public domain.
+.. Derived from the Unicode character mappings available from
+   <http://www.w3.org/2003/entities/xml/>.
+   Processed by unicode2rstsubs.py, part of Docutils:
+   <http://docutils.sourceforge.net>.
+
+.. |Aacute| unicode:: U+000C1 .. LATIN CAPITAL LETTER A WITH ACUTE
+.. |aacute| unicode:: U+000E1 .. LATIN SMALL LETTER A WITH ACUTE
+.. |Acirc|  unicode:: U+000C2 .. LATIN CAPITAL LETTER A WITH CIRCUMFLEX
+.. |acirc|  unicode:: U+000E2 .. LATIN SMALL LETTER A WITH CIRCUMFLEX
+.. |acute|  unicode:: U+000B4 .. ACUTE ACCENT
+.. |AElig|  unicode:: U+000C6 .. LATIN CAPITAL LETTER AE
+.. |aelig|  unicode:: U+000E6 .. LATIN SMALL LETTER AE
+.. |Agrave| unicode:: U+000C0 .. LATIN CAPITAL LETTER A WITH GRAVE
+.. |agrave| unicode:: U+000E0 .. LATIN SMALL LETTER A WITH GRAVE
+.. |Aring|  unicode:: U+000C5 .. LATIN CAPITAL LETTER A WITH RING ABOVE
+.. |aring|  unicode:: U+000E5 .. LATIN SMALL LETTER A WITH RING ABOVE
+.. |Atilde| unicode:: U+000C3 .. LATIN CAPITAL LETTER A WITH TILDE
+.. |atilde| unicode:: U+000E3 .. LATIN SMALL LETTER A WITH TILDE
+.. |Auml|   unicode:: U+000C4 .. LATIN CAPITAL LETTER A WITH DIAERESIS
+.. |auml|   unicode:: U+000E4 .. LATIN SMALL LETTER A WITH DIAERESIS
+.. |brvbar| unicode:: U+000A6 .. BROKEN BAR
+.. |Ccedil| unicode:: U+000C7 .. LATIN CAPITAL LETTER C WITH CEDILLA
+.. |ccedil| unicode:: U+000E7 .. LATIN SMALL LETTER C WITH CEDILLA
+.. |cedil|  unicode:: U+000B8 .. CEDILLA
+.. |cent|   unicode:: U+000A2 .. CENT SIGN
+.. |copy|   unicode:: U+000A9 .. COPYRIGHT SIGN
+.. |curren| unicode:: U+000A4 .. CURRENCY SIGN
+.. |deg|    unicode:: U+000B0 .. DEGREE SIGN
+.. |divide| unicode:: U+000F7 .. DIVISION SIGN
+.. |Eacute| unicode:: U+000C9 .. LATIN CAPITAL LETTER E WITH ACUTE
+.. |eacute| unicode:: U+000E9 .. LATIN SMALL LETTER E WITH ACUTE
+.. |Ecirc|  unicode:: U+000CA .. LATIN CAPITAL LETTER E WITH CIRCUMFLEX
+.. |ecirc|  unicode:: U+000EA .. LATIN SMALL LETTER E WITH CIRCUMFLEX
+.. |Egrave| unicode:: U+000C8 .. LATIN CAPITAL LETTER E WITH GRAVE
+.. |egrave| unicode:: U+000E8 .. LATIN SMALL LETTER E WITH GRAVE
+.. |ETH|    unicode:: U+000D0 .. LATIN CAPITAL LETTER ETH
+.. |eth|    unicode:: U+000F0 .. LATIN SMALL LETTER ETH
+.. |Euml|   unicode:: U+000CB .. LATIN CAPITAL LETTER E WITH DIAERESIS
+.. |euml|   unicode:: U+000EB .. LATIN SMALL LETTER E WITH DIAERESIS
+.. |frac12| unicode:: U+000BD .. VULGAR FRACTION ONE HALF
+.. |frac14| unicode:: U+000BC .. VULGAR FRACTION ONE QUARTER
+.. |frac34| unicode:: U+000BE .. VULGAR FRACTION THREE QUARTERS
+.. |Iacute| unicode:: U+000CD .. LATIN CAPITAL LETTER I WITH ACUTE
+.. |iacute| unicode:: U+000ED .. LATIN SMALL LETTER I WITH ACUTE
+.. |Icirc|  unicode:: U+000CE .. LATIN CAPITAL LETTER I WITH CIRCUMFLEX
+.. |icirc|  unicode:: U+000EE .. LATIN SMALL LETTER I WITH CIRCUMFLEX
+.. |iexcl|  unicode:: U+000A1 .. INVERTED EXCLAMATION MARK
+.. |Igrave| unicode:: U+000CC .. LATIN CAPITAL LETTER I WITH GRAVE
+.. |igrave| unicode:: U+000EC .. LATIN SMALL LETTER I WITH GRAVE
+.. |iquest| unicode:: U+000BF .. INVERTED QUESTION MARK
+.. |Iuml|   unicode:: U+000CF .. LATIN CAPITAL LETTER I WITH DIAERESIS
+.. |iuml|   unicode:: U+000EF .. LATIN SMALL LETTER I WITH DIAERESIS
+.. |laquo|  unicode:: U+000AB .. LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+.. |macr|   unicode:: U+000AF .. MACRON
+.. |micro|  unicode:: U+000B5 .. MICRO SIGN
+.. |middot| unicode:: U+000B7 .. MIDDLE DOT
+.. |nbsp|   unicode:: U+000A0 .. NO-BREAK SPACE
+.. |not|    unicode:: U+000AC .. NOT SIGN
+.. |Ntilde| unicode:: U+000D1 .. LATIN CAPITAL LETTER N WITH TILDE
+.. |ntilde| unicode:: U+000F1 .. LATIN SMALL LETTER N WITH TILDE
+.. |Oacute| unicode:: U+000D3 .. LATIN CAPITAL LETTER O WITH ACUTE
+.. |oacute| unicode:: U+000F3 .. LATIN SMALL LETTER O WITH ACUTE
+.. |Ocirc|  unicode:: U+000D4 .. LATIN CAPITAL LETTER O WITH CIRCUMFLEX
+.. |ocirc|  unicode:: U+000F4 .. LATIN SMALL LETTER O WITH CIRCUMFLEX
+.. |Ograve| unicode:: U+000D2 .. LATIN CAPITAL LETTER O WITH GRAVE
+.. |ograve| unicode:: U+000F2 .. LATIN SMALL LETTER O WITH GRAVE
+.. |ordf|   unicode:: U+000AA .. FEMININE ORDINAL INDICATOR
+.. |ordm|   unicode:: U+000BA .. MASCULINE ORDINAL INDICATOR
+.. |Oslash| unicode:: U+000D8 .. LATIN CAPITAL LETTER O WITH STROKE
+.. |oslash| unicode:: U+000F8 .. LATIN SMALL LETTER O WITH STROKE
+.. |Otilde| unicode:: U+000D5 .. LATIN CAPITAL LETTER O WITH TILDE
+.. |otilde| unicode:: U+000F5 .. LATIN SMALL LETTER O WITH TILDE
+.. |Ouml|   unicode:: U+000D6 .. LATIN CAPITAL LETTER O WITH DIAERESIS
+.. |ouml|   unicode:: U+000F6 .. LATIN SMALL LETTER O WITH DIAERESIS
+.. |para|   unicode:: U+000B6 .. PILCROW SIGN
+.. |plusmn| unicode:: U+000B1 .. PLUS-MINUS SIGN
+.. |pound|  unicode:: U+000A3 .. POUND SIGN
+.. |raquo|  unicode:: U+000BB .. RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+.. |reg|    unicode:: U+000AE .. REGISTERED SIGN
+.. |sect|   unicode:: U+000A7 .. SECTION SIGN
+.. |shy|    unicode:: U+000AD .. SOFT HYPHEN
+.. |sup1|   unicode:: U+000B9 .. SUPERSCRIPT ONE
+.. |sup2|   unicode:: U+000B2 .. SUPERSCRIPT TWO
+.. |sup3|   unicode:: U+000B3 .. SUPERSCRIPT THREE
+.. |szlig|  unicode:: U+000DF .. LATIN SMALL LETTER SHARP S
+.. |THORN|  unicode:: U+000DE .. LATIN CAPITAL LETTER THORN
+.. |thorn|  unicode:: U+000FE .. LATIN SMALL LETTER THORN
+.. |times|  unicode:: U+000D7 .. MULTIPLICATION SIGN
+.. |Uacute| unicode:: U+000DA .. LATIN CAPITAL LETTER U WITH ACUTE
+.. |uacute| unicode:: U+000FA .. LATIN SMALL LETTER U WITH ACUTE
+.. |Ucirc|  unicode:: U+000DB .. LATIN CAPITAL LETTER U WITH CIRCUMFLEX
+.. |ucirc|  unicode:: U+000FB .. LATIN SMALL LETTER U WITH CIRCUMFLEX
+.. |Ugrave| unicode:: U+000D9 .. LATIN CAPITAL LETTER U WITH GRAVE
+.. |ugrave| unicode:: U+000F9 .. LATIN SMALL LETTER U WITH GRAVE
+.. |uml|    unicode:: U+000A8 .. DIAERESIS
+.. |Uuml|   unicode:: U+000DC .. LATIN CAPITAL LETTER U WITH DIAERESIS
+.. |uuml|   unicode:: U+000FC .. LATIN SMALL LETTER U WITH DIAERESIS
+.. |Yacute| unicode:: U+000DD .. LATIN CAPITAL LETTER Y WITH ACUTE
+.. |yacute| unicode:: U+000FD .. LATIN SMALL LETTER Y WITH ACUTE
+.. |yen|    unicode:: U+000A5 .. YEN SIGN
+.. |yuml|   unicode:: U+000FF .. LATIN SMALL LETTER Y WITH DIAERESIS

--- a/docs/src/static/parsers/xhtml1-special.txt
+++ b/docs/src/static/parsers/xhtml1-special.txt
@@ -1,0 +1,37 @@
+.. This data file has been placed in the public domain.
+.. Derived from the Unicode character mappings available from
+   <http://www.w3.org/2003/entities/xml/>.
+   Processed by unicode2rstsubs.py, part of Docutils:
+   <http://docutils.sourceforge.net>.
+
+.. |bdquo|  unicode:: U+0201E .. DOUBLE LOW-9 QUOTATION MARK
+.. |circ|   unicode:: U+002C6 .. MODIFIER LETTER CIRCUMFLEX ACCENT
+.. |Dagger| unicode:: U+02021 .. DOUBLE DAGGER
+.. |dagger| unicode:: U+02020 .. DAGGER
+.. |emsp|   unicode:: U+02003 .. EM SPACE
+.. |ensp|   unicode:: U+02002 .. EN SPACE
+.. |euro|   unicode:: U+020AC .. EURO SIGN
+.. |gt|     unicode:: U+0003E .. GREATER-THAN SIGN
+.. |ldquo|  unicode:: U+0201C .. LEFT DOUBLE QUOTATION MARK
+.. |lrm|    unicode:: U+0200E .. LEFT-TO-RIGHT MARK
+.. |lsaquo| unicode:: U+02039 .. SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+.. |lsquo|  unicode:: U+02018 .. LEFT SINGLE QUOTATION MARK
+.. |lt|     unicode:: U+0003C .. LESS-THAN SIGN
+.. |mdash|  unicode:: U+02014 .. EM DASH
+.. |ndash|  unicode:: U+02013 .. EN DASH
+.. |OElig|  unicode:: U+00152 .. LATIN CAPITAL LIGATURE OE
+.. |oelig|  unicode:: U+00153 .. LATIN SMALL LIGATURE OE
+.. |permil| unicode:: U+02030 .. PER MILLE SIGN
+.. |quot|   unicode:: U+00022 .. QUOTATION MARK
+.. |rdquo|  unicode:: U+0201D .. RIGHT DOUBLE QUOTATION MARK
+.. |rlm|    unicode:: U+0200F .. RIGHT-TO-LEFT MARK
+.. |rsaquo| unicode:: U+0203A .. SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+.. |rsquo|  unicode:: U+02019 .. RIGHT SINGLE QUOTATION MARK
+.. |sbquo|  unicode:: U+0201A .. SINGLE LOW-9 QUOTATION MARK
+.. |Scaron| unicode:: U+00160 .. LATIN CAPITAL LETTER S WITH CARON
+.. |scaron| unicode:: U+00161 .. LATIN SMALL LETTER S WITH CARON
+.. |thinsp| unicode:: U+02009 .. THIN SPACE
+.. |tilde|  unicode:: U+002DC .. SMALL TILDE
+.. |Yuml|   unicode:: U+00178 .. LATIN CAPITAL LETTER Y WITH DIAERESIS
+.. |zwj|    unicode:: U+0200D .. ZERO WIDTH JOINER
+.. |zwnj|   unicode:: U+0200C .. ZERO WIDTH NON-JOINER

--- a/docs/src/usage.rst
+++ b/docs/src/usage.rst
@@ -68,6 +68,7 @@ Kubeinit spec
 Currently the inventory to deploy the clusters is dynamic,
 this means that it is configured based on the variables that are
 passed to the deployment command.
+The first hypervisor is denoted also as the bastion host or |Dagger|.
 
 In particular the `kubeinit_spec` variable will determine the
 amount of controller nodes, compute nodes, and hypervisors that
@@ -120,8 +121,8 @@ the hypervisor's IP address. Also when running the
 deployment as a user different than root, the
 keys needs to be also updated.
 
-|bull| Running from the GIT repository
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Running from the GIT repository
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
@@ -138,8 +139,8 @@ keys needs to be also updated.
             -i ./kubeinit/inventory \
             ./kubeinit/playbook.yml
 
-|bull| Running from a release
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Running from a release
+^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: console
 
@@ -158,8 +159,8 @@ keys needs to be also updated.
 Connecting to the cluster
 -------------------------
 
-|bull| Accessing the cluster resources internally
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Accessing the cluster resources internally
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Once the deployment is finished the machine used
 for provisioning the cluster have access to both
@@ -197,8 +198,8 @@ For instance:
     .kube/config
 
 
-|bull| Accessing the cluster resources externally
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Accessing the cluster resources externally
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When the services deployment is executed
 one of the tasks in the kubeinit_bind role
@@ -250,4 +251,6 @@ in the hypervisors its also possible to add the following variable
    docs pages, this is fetched from Docutils
    https://docutils.sourceforge.io/docutils/parsers/rst/include/
 
+.. include:: static/parsers/xhtml1-lat1.txt
+.. include:: static/parsers/xhtml1-special.txt
 .. include:: static/parsers/xhtml1-symbol.txt


### PR DESCRIPTION
This commit includes the extra symbols available in
the rst pages.