### PR TITLE
fix: move to OVNKubernetes

### DIFF
--- a/kubeinit/roles/kubeinit_okd/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_okd/defaults/main.yml
@@ -64,7 +64,7 @@ kubeinit_okd_registry_repository: "{{ kubeinit_okd_registry_repository_aux | rep
 kubeinit_okd_registry_release_tag_aux: "{% if ( kubeinit_okd_openshift_deploy | default(False) ) %}
                                               4.7.18
                                         {% else %}
-                                              4.8.0-0.okd-2021-11-14-052418
+                                              4.9.0-0.okd-2021-11-28-035710
                                         {% endif %}"
 kubeinit_okd_registry_release_tag: "{{ kubeinit_okd_registry_release_tag_aux | replace(' ','') }}"
 

--- a/kubeinit/roles/kubeinit_okd/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_okd/tasks/main.yml
@@ -156,26 +156,11 @@
 - name: Complete the cluster deployment on the provision service node
   block:
 
-    - name: "verify that all the csr are loaded and aproved for the deployed nodes"
-      ansible.builtin.shell: |
-        set -o pipefail
-        export KUBECONFIG=~/install_dir/auth/kubeconfig; \
-        oc get csr -ojson | jq -r '.items[] | .metadata.name' | xargs oc adm certificate approve >/dev/null 2>&1; \
-        oc get csr | grep Approved
-      args:
-        executable: /bin/bash
-      register: _result
-      changed_when: "_result.rc == 0"
-      retries: 60
-      delay: 60
-      # Per each node we have 2 csrs, one per kubelet-serving and another per kube-apiserver-client-kubelet
-      # Per cluster we have an additonal csr per kube-apiserver-client for openshift-authenticator
-      until: _result.stdout_lines | default([]) | list | length == (kubeinit_cluster_node_count|int * 2) + 1
-
     - name: "wait until all nodes are ready"
       ansible.builtin.shell: |
         set -o pipefail
         export KUBECONFIG=~/install_dir/auth/kubeconfig; \
+        oc get csr -ojson | jq -r '.items[] | .metadata.name' | xargs oc adm certificate approve >/dev/null 2>&1; \
         oc get nodes | grep " Ready"
       args:
         executable: /bin/bash

--- a/kubeinit/roles/kubeinit_okd/templates/install-config.yaml.j2
+++ b/kubeinit/roles/kubeinit_okd/templates/install-config.yaml.j2
@@ -14,7 +14,7 @@ networking:
   clusterNetwork:
     - cidr: {{ kubeinit_okd_pod_cidr }}
       hostPrefix: 23
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes
   serviceNetwork:
     - {{ kubeinit_okd_service_cidr }}
 platform:


### PR DESCRIPTION
This commit moves the default CNI
cluster network provider to
OVNKubernetes as it will be the
eventual default.