### PR TITLE
feat: add ansible setup for kubeinit

### DIFF
--- a/kubeinit/galaxy.yml
+++ b/kubeinit/galaxy.yml
@@ -23,13 +23,13 @@ tags:
   - rancher
   - aws
 dependencies:
-  ansible.posix: '==1.2.0'
+  ansible.posix: '==1.3.0'
   # crypto 1.4.0 is the latest without requiring rust
   # do not upgrade this unles is strictly necessary
   community.crypto: '==1.4.0'
-  community.general: '==3.2.0'
-  community.libvirt: '==1.0.1'
-  containers.podman: '==1.6.1'
+  community.general: '==3.8.3'
+  community.libvirt: '==1.0.2'
+  containers.podman: '==1.8.3'
   openvswitch.openvswitch: '==2.0.2'
 repository: 'https://github.com/kubeinit/kubeinit'
 homepage: 'https://www.kubeinit.org'

--- a/kubeinit/requirements.yml
+++ b/kubeinit/requirements.yml
@@ -5,16 +5,16 @@
 ---
 collections:
   - name: ansible.posix
-    version: '1.2.0'
+    version: '1.3.0'
   # crypto 1.4.0 is the latest without requiring rust
   # do not upgrade this unles is strictly necessary
   - name: community.crypto
     version: '1.4.0'
   - name: community.general
-    version: '3.2.0'
+    version: '3.8.3'
   - name: community.libvirt
-    version: '1.0.1'
+    version: '1.0.2'
   - name: containers.podman
-    version: '1.6.1'
+    version: '1.8.3'
   - name: openvswitch.openvswitch
     version: '2.0.2'

--- a/setup/group_vars/all.yml
+++ b/setup/group_vars/all.yml
@@ -1,0 +1,3 @@
+---
+
+kubeinit_common_ssh_keytype: "{{ lookup('env','KUBEINIT_COMMON_SSH_KEYTYPE') or 'rsa' }}"

--- a/setup/inventory
+++ b/setup/inventory
@@ -1,0 +1,45 @@
+#
+# Common variables for the inventory
+#
+
+[all:vars]
+
+#
+# Internal variables
+#
+
+ansible_python_interpreter=/usr/bin/python3
+ansible_ssh_pipelining=True
+ansible_ssh_common_args='-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=accept-new'
+
+#
+# Inventory variables
+#
+
+kubeinit_setup_inventory_remote_user=root
+kubeinit_setup_inventory_domain=kubeinit.local
+
+#
+# Hypervisor host definitions
+#
+
+[hypervisor_hosts]
+nyctea ansible_host=192.168.222.201
+tyto ansible_host=192.168.222.202
+strix ansible_host=192.168.222.203
+otus ansible_host=192.168.222.204
+
+#
+# Setup host definition
+#
+
+# This inventory will have one host identified as the setup host. By default, this function
+# will be assumed by the first hypervisor host, which is the same behavior as the first commented
+# out line. The second commented out line would set the second hypervisor to be the setup
+# host. The final commented out line would set the setup host to be a different host that is
+# not being used as a hypervisor in this inventory.
+
+[setup_host]
+# kubeinit-setup target=nyctea
+# kubeinit-setup target=tyto
+# kubeinit-setup ansible_host=192.168.222.214

--- a/setup/playbook.yml
+++ b/setup/playbook.yml
@@ -1,0 +1,65 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Setup KubeInit deployment environment
+  hosts: localhost
+  become: false
+  remote_user: root
+  gather_subset: "!all,network"
+  pre_tasks:
+    - name: Check if Ansible meets version requirements.
+      tags: task_gather_facts
+      vars:
+        kubeinit_ansible_min_version: 2.9
+      ansible.builtin.assert:
+        that: "ansible_version.full is version_compare('{{ kubeinit_ansible_min_version }}', '>=')"
+        msg: >
+          "You must update Ansible to at least {{ kubeinit_ansible_min_version }} to use KubeInit."
+  tasks:
+    - name: Gather facts about the deployment environment
+      tags: task_gather_facts
+      block:
+        - name: task-gather-facts
+          ansible.builtin.include_role:
+            name: "kubeinit_setup"
+            tasks_from: gather_setup_facts.yml
+            public: true
+
+    - name: Prepare the environment
+      tags: task_prepare_environment
+      block:
+        - name: task-prepare-environment
+          ansible.builtin.include_role:
+            name: "kubeinit_setup"
+            tasks_from: prepare_environment.yml
+            public: true
+
+    - name: Cleanup any remnants of previous setup deployments
+      tags: task_cleanup_deployment
+      block:
+        - name: task-cleanup-deployment
+          ansible.builtin.include_role:
+            name: "kubeinit_setup"
+            tasks_from: cleanup_deployment.yml
+            public: true
+
+    - name: Deploy the setup
+      tags: task_deploy_setup
+      block:
+        - name: task-deploy-setup
+          ansible.builtin.include_role:
+            name: "kubeinit_setup"
+            public: true

--- a/setup/roles/kubeinit_setup/tasks/cleanup_deployment.yml
+++ b/setup/roles/kubeinit_setup/tasks/cleanup_deployment.yml
@@ -1,0 +1,52 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- block:
+    - name: Prepare environment if needed
+      ansible.builtin.include_tasks: prepare_environment.yml
+      vars:
+        environment_prepared: "{{ kubeinit_setup_facts_name is defined }}"
+      when: not environment_prepared
+
+    - block:
+        - name: "Stop before 'task-cleanup-deployment' when requested"
+          ansible.builtin.add_host: name="{{ kubeinit_setup_facts_name }}" playbook_terminated=true
+        - name: End play
+          ansible.builtin.meta: end_play
+      when: kubeinit_stop_before_task is defined and kubeinit_stop_before_task == 'task-cleanup-deployment'
+  tags: omit_from_grapher
+
+- name: Cleanup previous kubeinit setup
+  ansible.builtin.debug:
+    msg: "Add cleanup tasks after deployment tasks are written and tested"
+
+- block:
+    - name: Add task-cleanup-deployment to tasks_completed
+      ansible.builtin.add_host:
+        name: "{{ kubeinit_setup_facts_name }}"
+        tasks_completed: "{{ kubeinit_setup_hostvars.tasks_completed | union(['task-cleanup-deployment']) }}"
+
+    - name: Update kubeinit_setup_hostvars
+      ansible.builtin.set_fact:
+        kubeinit_setup_hostvars: "{{ hostvars[kubeinit_setup_facts_name] }}"
+
+    - block:
+        - name: Stop after 'task-cleanup-deployment' when requested
+          ansible.builtin.add_host: name="{{ kubeinit_setup_facts_name }}" playbook_terminated=true
+        - name: End play
+          ansible.builtin.meta: end_play
+      when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task in kubeinit_setup_hostvars.tasks_completed
+  tags: omit_from_grapher

--- a/setup/roles/kubeinit_setup/tasks/gather_host_facts.yml
+++ b/setup/roles/kubeinit_setup/tasks/gather_host_facts.yml
@@ -1,0 +1,144 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- name: Delegate to kubeinit_setup_gather_host
+  block:
+
+    - name: Gather network facts
+      ansible.builtin.gather_facts:
+        gather_subset: "!all,network"
+      register: _result_facts
+
+    - name: Set distro_family for CentOS
+      ansible.builtin.set_fact:
+        distro_family: "CentOS"
+        host_os: "centos"
+      when: _result_facts.ansible_facts.ansible_distribution == 'CentOS'
+
+    - name: Set distro_family for RedHat
+      ansible.builtin.set_fact:
+        distro_family: "CentOS"
+        host_os: "redhat"
+      when: _result_facts.ansible_facts.ansible_distribution == 'RedHat'
+
+    - name: Set distro_family for Fedora
+      ansible.builtin.set_fact:
+        distro_family: "Fedora"
+        host_os: "fedora"
+      when: _result_facts.ansible_facts.ansible_distribution == 'Fedora'
+
+    - name: Set distro_family for Debian
+      ansible.builtin.set_fact:
+        distro_family: "Debian"
+        host_os: "debian"
+      when: _result_facts.ansible_facts.ansible_distribution == 'Debian'
+
+    - name: Set distro_family for Ubuntu
+      ansible.builtin.set_fact:
+        distro_family: "Debian"
+        host_os: "ubuntu"
+      when: _result_facts.ansible_facts.ansible_distribution == 'Ubuntu'
+
+    - name: Fails if OS is not supported
+      ansible.builtin.fail:
+        msg: "The host \"{{ hostvars[kubeinit_setup_gather_host].ansible_host }}\" needs to be CentOS/RHEL, Fedora, or Debian/Ubuntu"
+      when: not distro_family is defined
+
+    - name: Gather the package facts
+      ansible.builtin.package_facts:
+      register: _result_packages
+
+    - name: Set podman_installed
+      ansible.builtin.set_fact:
+        podman_installed: "{{ true if ('podman' in _result_packages.ansible_facts.packages) else false }}"
+
+    - name: Gather the services facts
+      ansible.builtin.service_facts:
+      register: _result_services
+
+    - name: Set firewalld_state to unknown
+      ansible.builtin.set_fact:
+        firewalld_state: 'unknown'
+
+    - name: Set firewalld_state when firewalld is defined
+      ansible.builtin.set_fact:
+        firewalld_state: "{{ _result_services.ansible_facts.services['firewalld'].state }}"
+      when: _result_services.ansible_facts.services['firewalld'] is defined
+
+    - name: Set firewalld_state when firewalld.service is defined
+      ansible.builtin.set_fact:
+        firewalld_state: "{{ _result_services.ansible_facts.services['firewalld.service'].state }}"
+      when: _result_services.ansible_facts.services['firewalld.service'] is defined
+
+    - name: Set firewalld_active
+      ansible.builtin.set_fact:
+        firewalld_active: "{{ true if firewalld_state == 'running' else false }}"
+
+    - name: Clear podman_state
+      ansible.builtin.set_fact:
+        podman_state: ''
+
+    - name: Set podman_state when podman is defined
+      ansible.builtin.set_fact:
+        podman_state: "{{ _result_services.ansible_facts.services['podman'].state }}"
+      when: _result_services.ansible_facts.services['podman'] is defined
+
+    - name: Set podman_state when podman.service is defined
+      ansible.builtin.set_fact:
+        podman_state: "{{ _result_services.ansible_facts.services['podman.service'].state }}"
+      when: _result_services.ansible_facts.services['podman.service'] is defined
+
+    - name: Set podman_active
+      ansible.builtin.set_fact:
+        podman_active: "{{ true if podman_state == 'running' else false }}"
+
+    - name: Set ssh_host_key_info
+      ansible.builtin.set_fact:
+        ssh_host_key_info: "{{ _result_facts.ansible_facts.ansible_ssh_host_key_ecdsa_public_keytype }} {{ _result_facts.ansible_facts.ansible_ssh_host_key_ecdsa_public }}"
+      when: >
+        _result_facts.ansible_facts.ansible_ssh_host_key_ecdsa_public_keytype is defined and
+        _result_facts.ansible_facts.ansible_ssh_host_key_ecdsa_public is defined
+
+    - name: Add ansible facts to hostvars
+      ansible.builtin.add_host:
+        name: "{{ kubeinit_setup_gather_host }}"
+        ansible_default_ipv4_address: "{{ _result_facts.ansible_facts.ansible_default_ipv4.address | default(omit) }}"
+        ansible_hostname: "{{ _result_facts.ansible_facts.ansible_hostname }}"
+        ansible_distribution: "{{ _result_facts.ansible_facts.ansible_distribution }}"
+        ansible_distribution_major_version: "{{ _result_facts.ansible_facts.ansible_distribution_major_version }}"
+        distribution_family: "{{ distro_family }}"
+        ssh_host_key_ecdsa: "{{ ssh_host_key_info | default(omit) }}"
+        os: "{{ hostvars[kubeinit_setup_gather_host].os if (hostvars[kubeinit_setup_gather_host].os is defined) else host_os }}"
+        firewalld_is_active: "{{ firewalld_active }}"
+        podman_is_installed: "{{ podman_installed }}"
+        podman_is_active: "{{ podman_active }}"
+        remote_path: "{{ _result_facts.ansible_facts.ansible_env['PATH'] }}"
+        remote_home: "{{ _result_facts.ansible_facts.ansible_env['HOME'] }}"
+        ssh_connection_address: "{{ 'localhost' if (kubeinit_setup_gather_host == 'localhost') else _result_facts.ansible_facts.ansible_env['SSH_CONNECTION'].split(' ')[2] }}"
+        runtime_path: "{{ _result_facts.ansible_facts.ansible_env['XDG_RUNTIME_DIR'] | default('') | string }}"
+
+    - name: Update kubeinit_setup_hostvars
+      ansible.builtin.set_fact:
+        kubeinit_setup_hostvars: "{{ hostvars[kubeinit_setup_facts_name] }}"
+      when: kubeinit_setup_hostvars is defined
+
+    - name: Clear results
+      ansible.builtin.set_fact:
+        _result_facts: null
+        _result_packages: null
+        _result_services: null
+
+  delegate_to: "{{ kubeinit_setup_gather_host }}"

--- a/setup/roles/kubeinit_setup/tasks/gather_setup_facts.yml
+++ b/setup/roles/kubeinit_setup/tasks/gather_setup_facts.yml
@@ -1,0 +1,61 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- block:
+    - block:
+        - name: "Stop before 'task-gather-facts' when requested"
+          ansible.builtin.add_host: name='kubeinit-setup-facts' playbook_terminated=true
+        - name: End play
+          ansible.builtin.meta: end_play
+      when: kubeinit_stop_before_task is defined and kubeinit_stop_before_task == 'task-gather-facts'
+  tags: omit_from_grapher
+
+#
+# Gather kubeinit setup facts
+#
+- name: Add an explicit localhost entry to hostvars
+  ansible.builtin.add_host:
+    name: localhost
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+
+- name: Set hostname we use to store setup facts
+  ansible.builtin.set_fact:
+    kubeinit_setup_facts_name: 'kubeinit-setup-facts'
+
+- name: Set remote user fact from inventory
+  ansible.builtin.set_fact:
+    kubeinit_setup_remote_user: "{{ kubeinit_setup_inventory_remote_user | default('root') }}"
+
+- name: Add group facts to setup facts
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_setup_facts_name }}"
+    remote_user: "{{ kubeinit_setup_remote_user }}"
+    hypervisors: "{{ groups['hypervisor_hosts'] }}"
+
+- block:
+    - name: Add tasks-gather-facts to tasks completed
+      ansible.builtin.add_host:
+        name: "{{ kubeinit_setup_facts_name }}"
+        tasks_completed: "{{ ['task-gather-facts'] }}"
+
+    - block:
+        - name: Stop after 'task-gather-facts' when requested
+          ansible.builtin.add_host: name="{{ kubeinit_setup_facts_name }}" playbook_terminated=true
+        - name: End play
+          ansible.builtin.meta: end_play
+      when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task in hostvars[kubeinit_setup_facts_name].tasks_completed
+  tags: omit_from_grapher

--- a/setup/roles/kubeinit_setup/tasks/main.yml
+++ b/setup/roles/kubeinit_setup/tasks/main.yml
@@ -1,0 +1,172 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- block:
+    - name: Prepare environment if needed
+      ansible.builtin.include_tasks: prepare_environment.yml
+      vars:
+        environment_prepared: "{{ kubeinit_setup_facts_name is defined }}"
+      when: not environment_prepared
+
+    - block:
+        - name: "Stop before 'task-deploy-setup' when requested"
+          ansible.builtin.add_host: name="{{ kubeinit_setup_facts_name }}" playbook_terminated=true
+        - name: End play
+          ansible.builtin.meta: end_play
+      when: kubeinit_stop_before_task is defined and kubeinit_stop_before_task == 'task-deploy-setup'
+  tags: omit_from_grapher
+
+- name: Delegate to kubeinit_setup_host_name
+  block:
+
+    - name: Install latest pip module
+      ansible.builtin.pip:
+        name: pip
+        state: latest
+        extra_args: --user
+
+    - name: Install latest cryptography module
+      ansible.builtin.pip:
+        name: cryptography
+        state: latest
+        extra_args: --user
+
+    - name: Install latest shyaml ansible netaddr modules
+      ansible.builtin.pip:
+        name:
+          - shyaml
+          - ansible
+          - netaddr
+        state: latest
+        extra_args: --user
+
+    - name: Clone the kubeinit git repo
+      ansible.builtin.git:
+        clone: true
+        dest: ~/kubeinit
+        repo: https://github.com/Kubeinit/kubeinit.git
+        version: main
+
+    - name: Install ansible-galaxy requirements
+      community.general.ansible_galaxy_install:
+        type: collection
+        requirements_file: ~/kubeinit/kubeinit/requirements.yml
+        force: true
+
+    - name: Remove any existing kubeinit/kubeinit galaxy collection
+      ansible.builtin.file:
+        path: ~/.ansible/collections/ansible_collections/kubeinit/kubeinit
+        state: absent
+
+    - name: Build the kubeinit/kubeinit galaxy collection
+      ansible.builtin.command:
+        chdir: ~/kubeinit
+        cmd: ansible-galaxy collection build kubeinit --verbose --force --output-path releases/
+      register: _result
+
+    - name: Read the kubeinit/galaxy.xml file
+      ansible.builtin.command:
+        chdir: ~/kubeinit
+        cmd: cat kubeinit/galaxy.yml
+      register: _result
+
+    - name: Set galaxy file facts
+      ansible.builtin.set_fact:
+        galaxy_facts: "{{ _result.stdout | from_yaml }}"
+
+    - name: Install the kubeinit/kubeinit galaxy collection
+      ansible.builtin.command:
+        chdir: ~/kubeinit
+        cmd: ansible-galaxy collection install --force --force-with-deps releases/kubeinit-kubeinit-{{ galaxy_facts.version }}.tar.gz
+      register: _result
+      failed_when: _result is not defined
+
+    - name: Create ~/.ssh/config from template
+      ansible.builtin.template:
+        src: ssh-config.j2
+        dest: ~/.ssh/config
+        mode: '0644'
+
+    - name: Generate an OpenSSH keypair for setup_host to have remote access to hypervisor hosts
+      community.crypto.openssh_keypair:
+        path: "{{ kubeinit_setup_keypair_path }}"
+        type: "{{ kubeinit_common_ssh_keytype }}"
+        comment: "{{ kubeinit_setup_host_fqdn }}"
+        regenerate: 'never'
+      register: _result_setup_keypair
+
+    - name: Add host keys to known_hosts
+      ansible.builtin.known_hosts:
+        name: "{{ hostvars[item].ansible_host }}"
+        key: "{{ hostvars[item].ansible_host }} {{ hostvars[item].ssh_host_key_ecdsa }}"
+        state: present
+      loop: "{{ groups['hypervisor_hosts'] }}"
+
+    - name: Add setup_host public key to hypervisor hosts
+      ansible.posix.authorized_key:
+        user: root
+        key: "{{ _result_setup_keypair.public_key }}"
+        comment: "{{ _result_setup_keypair.comment }}"
+        state: present
+      loop: "{{ groups['hypervisor_hosts'] }}"
+      loop_control:
+        loop_var: hypervisor_host
+      vars:
+        ansible_ssh_extra_args: "-i ~/.ssh/id_{{ kubeinit_common_ssh_keytype }}"
+      delegate_to: "{{ hypervisor_host }}"
+
+    - name: Confirm access to hypervisors from setup host and user
+      ansible.builtin.shell: |
+        set -o pipefail
+        ssh \
+            -i {{ kubeinit_setup_keypair_path }} \
+            -o ConnectTimeout=5 \
+            -o BatchMode=yes \
+            -o UserKnownHostsFile=/dev/null \
+            -o StrictHostKeyChecking=accept-new \
+            root@{{ hostvars[hypervisor_host].ansible_host }} 'echo connected' || true
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+      retries: 30
+      delay: 10
+      until: "'connected' in _result.stdout"
+      loop: "{{ groups['hypervisor_hosts'] }}"
+      loop_control:
+        loop_var: hypervisor_host
+
+  environment:
+    PATH: "{{ hostvars[kubeinit_setup_host_name].remote_home }}/.local/bin:{{ hostvars[kubeinit_setup_host_name].remote_path }}"
+  delegate_to: "{{ kubeinit_setup_host_name }}"
+
+- block:
+    - name: Add task-deploy-setup to tasks_completed
+      ansible.builtin.add_host:
+        name: "{{ kubeinit_setup_facts_name }}"
+        tasks_completed: "{{ kubeinit_setup_hostvars.tasks_completed | union(['task-deploy-setup']) }}"
+
+    - name: Update kubeinit_setup_hostvars
+      ansible.builtin.set_fact:
+        kubeinit_setup_hostvars: "{{ hostvars[kubeinit_setup_facts_name] }}"
+
+    - block:
+        - name: Stop after 'task-deploy-setup' when requested
+          ansible.builtin.add_host: name="{{ kubeinit_setup_facts_name }}" playbook_terminated=true
+        - name: End play
+          ansible.builtin.meta: end_play
+      when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task in kubeinit_setup_hostvars.tasks_completed
+  tags: omit_from_grapher

--- a/setup/roles/kubeinit_setup/tasks/prepare_environment.yml
+++ b/setup/roles/kubeinit_setup/tasks/prepare_environment.yml
@@ -1,0 +1,133 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+- block:
+    - name: Gather kubeinit setup facts if needed
+      ansible.builtin.include_tasks: gather_setup_facts.yml
+      vars:
+        facts_prepared: "{{ kubeinit_setup_facts_name is defined }}"
+      when: not facts_prepared
+
+    - block:
+        - name: "Stop before 'task-prepare-environment' when requested"
+          ansible.builtin.add_host: name="{{ kubeinit_setup_facts_name }}" playbook_terminated=true
+        - name: End play
+          ansible.builtin.meta: end_play
+      when: kubeinit_stop_before_task is defined and kubeinit_stop_before_task == 'task-prepare-environment'
+  tags: omit_from_grapher
+
+- name: Define kubeinit_setup_hostvars
+  ansible.builtin.set_fact:
+    kubeinit_setup_hostvars: "{{ hostvars[kubeinit_setup_facts_name] }}"
+
+- name: Define setup fact names needed to prepare groups
+  ansible.builtin.set_fact:
+    kubeinit_setup_hypervisor_count: "{{ kubeinit_setup_hostvars.hypervisors | length }}"
+    kubeinit_setup_host_name:
+      "{{ 'kubeinit-setup' if (('setup_host' not in groups) or ((groups['setup_host'] | list | length) == 0)) else groups['setup_host'][0] }}"
+
+- name: Add a default entry for the first hypervisor if there are no setup_host members
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_setup_host_name }}"
+    group: setup_host
+    target: "{{ groups['hypervisor_hosts'][0] }}"
+  when: "('setup_host' not in groups) or ((groups['setup_host'] | list | length) == 0)"
+
+- name: Add remote_user for setup_host
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_setup_host_name }}"
+    group: setup_host
+    remote_user: "{{ kubeinit_setup_hostvars.remote_user }}"
+    ansible_ssh_user: "{{ kubeinit_setup_hostvars.remote_user }}"
+    ansible_ssh_extra_args: "-i ~/.ssh/id_{{ kubeinit_common_ssh_keytype }}"
+
+- name: Add ansible_host for setup_host if not defined
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_setup_host_name }}"
+    group: setup_host
+    ansible_host: "{{ hostvars[hostvars[kubeinit_setup_host_name].target].ansible_host }}"
+  when: "hostvars[kubeinit_setup_host_name].ansible_host is not defined"
+
+- name: Add target for setup_host if not defined
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_setup_host_name }}"
+    group: setup_host
+    target: "{{ kubeinit_setup_host_name }}"
+  when: "hostvars[kubeinit_setup_host_name].target is not defined"
+
+- name: Check to see if we have access to setup_host
+  ansible.builtin.ping:
+  vars:
+    ansible_ssh_user: "{{ hostvars[groups['setup_host'][0]].remote_user }}"
+    ansible_ssh_extra_args: "-i ~/.ssh/id_{{ kubeinit_common_ssh_keytype }}"
+  delegate_to: "{{ kubeinit_setup_host_name }}"
+
+- name: Gather facts from setup_host
+  ansible.builtin.include_tasks: gather_host_facts.yml
+  vars:
+    ansible_ssh_user: "{{ hostvars[groups['setup_host'][0]].remote_user }}"
+    ansible_ssh_extra_args: "-i ~/.ssh/id_{{ kubeinit_common_ssh_keytype }}"
+    kubeinit_setup_gather_host: "{{ kubeinit_setup_host_name }}"
+
+- name: Define additional host facts
+  ansible.builtin.set_fact:
+    kubeinit_setup_host_fqdn: "{{ kubeinit_setup_host_name }}.{{ kubeinit_setup_inventory_domain }}"
+    kubeinit_setup_host_address: "{{ hostvars[kubeinit_setup_host_name].ssh_connection_address }}"
+    kubeinit_setup_host_user: "{{ kubeinit_setup_hostvars.remote_user }}"
+    kubeinit_setup_keypair_path: "~/.ssh/kubeinit_setup_id_{{ kubeinit_common_ssh_keytype }}"
+
+- name: Confirm presence of podman and git packages
+  ansible.builtin.package_facts:
+  failed_when: "'podman' not in ansible_facts.packages or 'git' not in ansible_facts.packages"
+  delegate_to: "{{ kubeinit_setup_host_name }}"
+  when: ansible_check_mode
+
+- name: Install podman and git packages
+  ansible.builtin.package:
+    name:
+      - podman
+      - git
+    state: present
+  become: true
+  become_user: root
+  delegate_to: "{{ kubeinit_setup_host_name }}"
+  when: not ansible_check_mode
+
+- name: Gather hypervisor host facts
+  ansible.builtin.include_tasks: gather_host_facts.yml
+  loop: "{{ kubeinit_setup_hostvars.hypervisors }}"
+  loop_control:
+    loop_var: kubeinit_setup_gather_host
+  vars:
+    ansible_ssh_extra_args: "-i ~/.ssh/id_{{ kubeinit_common_ssh_keytype }}"
+
+- block:
+    - name: Add task-prepare-environment to tasks_completed
+      ansible.builtin.add_host:
+        name: "{{ kubeinit_setup_facts_name }}"
+        tasks_completed: "{{ kubeinit_setup_hostvars.tasks_completed | union(['task-prepare-environment']) }}"
+
+    - name: Update kubeinit_setup_hostvars
+      ansible.builtin.set_fact:
+        kubeinit_setup_hostvars: "{{ hostvars[kubeinit_setup_facts_name] }}"
+
+    - block:
+        - name: Stop after 'task-prepare-environment' when requested
+          ansible.builtin.add_host: name="{{ kubeinit_setup_facts_name }}" playbook_terminated=true
+        - name: End play
+          ansible.builtin.meta: end_play
+      when: kubeinit_stop_after_task is defined and kubeinit_stop_after_task in kubeinit_setup_hostvars.tasks_completed
+  tags: omit_from_grapher

--- a/setup/roles/kubeinit_setup/templates/ssh-config.j2
+++ b/setup/roles/kubeinit_setup/templates/ssh-config.j2
@@ -1,0 +1,10 @@
+Host *
+  IdentityFile ~/.ssh/kubeinit_setup_id_{{ kubeinit_common_ssh_keytype }}
+  UserKnownHostsFile /dev/null
+  StrictHostKeyChecking accept-new
+
+{% for host in groups['hypervisor_hosts'] | list %}
+Host {{ host }}
+  Hostname {{ hostvars[host].ssh_connection_address }}
+
+{% endfor %}


### PR DESCRIPTION
This commit adds a new setup folder that contains an inventory
and playbook that can be used to initialize a new ansible env
where kubeinit has been setup and is ready for immediate use
for deployments, testing, development, etc.