### PR TITLE
ci: include libselinux-python3 in selinux based hosts

### DIFF
--- a/ci/install_gitlab_node.sh
+++ b/ci/install_gitlab_node.sh
@@ -110,7 +110,8 @@ sysctl -p
 
 if [ -f /etc/redhat-release ] || [ -f /etc/fedora-release ]; then
     yum install -y nano git podman curl python3 python3-pip
-
+    # Install selinux python bindings
+    yum install -y libselinux-python3
     # ARA required packages
     yum install -y gcc python3-devel libffi-devel openssl-devel redhat-rpm-config
     yum install -y sqlite

--- a/ci/launch_e2e.py
+++ b/ci/launch_e2e.py
@@ -277,7 +277,7 @@ def main(cluster_type, job_type):
                 else:
                     state = "failure"
                 dur_mins = str(round((time.time() - start_time) / 60, 2))
-                issue = repo.get_issue(number=489)
+                issue = repo.get_issue(number=595)
                 issue.create_comment(body="%s-%s-%s-%s-%s-%s-%s-%s-%s" % (distro,
                                                                           driver,
                                                                           masters,


### PR DESCRIPTION
This commit includes the libselinux-python3 package in
the Fedora/CentOS/RHEL hosts.