### PR TITLE
ci: include b2sdk in the Github jobs status

### DIFF
--- a/.github/workflows/render_periodic_jobs_status_page.yml
+++ b/.github/workflows/render_periodic_jobs_status_page.yml
@@ -25,6 +25,7 @@ jobs:
           sudo python3 -m pip install --upgrade pip
           sudo python3 -m pip install --upgrade protobuf
           sudo python3 -m pip install google-cloud-storage
+          sudo python3 -m pip install b2sdk
           sudo python3 ./ci/render_periodic_jobs_page.py
       - name: Commit a PR rendered page
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
This commit includes the b2sdk dependency
for the GitHub status page render job.