### PR TITLE
ci: include the job type in all PR triggers

### DIFF
--- a/ci/gitlab_ci_trigger.sh
+++ b/ci/gitlab_ci_trigger.sh
@@ -81,7 +81,7 @@ run_pr() {
 
     if [ "$ci_label_found" -eq "0" ]; then
         echo "(gitlab_ci_trigger.sh) ==> We didnt find any PR matching a job label"
-        test_params="--pr_id=none "
+        test_params="--job_type=pr --pr_id=none "
     else
         echo "(gitlab_ci_trigger.sh) ==> We found a PR that will be tested with a valid label"
         echo "(gitlab_ci_trigger.sh) ==> Downloading KubeInit's code that will be tested ..."
@@ -130,6 +130,10 @@ main() {
 
     if [ "$ci_mock_cmd" -eq "0" ]; then
         echo "(gitlab_ci_trigger.sh) ==> Run the deployment script"
+        if [[ "${test_params}" == *pr* ]] && [[ "${test_params}" == *none* ]] ; then
+            echo "(gitlab_ci_trigger.sh) ==> There is no open PRs with labels"
+            exit 0
+        fi
         ${ci_cmd}
     else
         echo "(gitlab_ci_trigger.sh) ==> Mock test"

--- a/ci/gitlab_ci_trigger_test.sh
+++ b/ci/gitlab_ci_trigger_test.sh
@@ -83,8 +83,8 @@ fi
 # This should return a
 echo "(gitlab_ci_trigger_test.sh) ==> Run pr job"
 TEST_RESULT=$(JOB_TYPE='pr' ci_mock_cmd=1 ./ci/gitlab_ci_trigger.sh 2>&1)
-TEST_RESULT_NONE_REGEX='OUTPUT: ./ci/launch_e2e.py --pr_id=none'
-TEST_RESULT_REGEX='OUTPUT: .\/ci\/launch_e2e\.py (--verbosity=v+)|(--pr_id=[0-9]+)|(--job_label=[a-z]+-[a-z]+-[1|3]-[0-9]-[0-9]-h)'
+TEST_RESULT_NONE_REGEX='OUTPUT: ./ci/launch_e2e.py --job_type=pr --pr_id=none'
+TEST_RESULT_REGEX='OUTPUT: .\/ci\/launch_e2e\.py --job_type=pr (--verbosity=v+)|(--pr_id=[0-9]+)|(--job_label=[a-z]+-[a-z]+-[1|3]-[0-9]-[0-9]-h)'
 
 if [[ $TEST_RESULT =~ $TEST_RESULT_NONE_REGEX ]]; then
     echo "(gitlab_ci_trigger_test.sh) ==> PR job unit test passed"

--- a/ci/launch_e2e.py
+++ b/ci/launch_e2e.py
@@ -547,8 +547,11 @@ if __name__ == "__main__":
     print(args)
     print("---")
 
-    main(job_type=args.job_type,
-         cluster_type=args.cluster_type,
-         job_label=args.job_label,
-         pr_id=args.pr_id,
-         verbosity=args.verbosity)
+    if args.job_type == 'pr' and args.pr_id == 'none':
+        print("'launch_e2e.py' ==> Nothing to do here")
+    else:
+        main(job_type=args.job_type,
+             cluster_type=args.cluster_type,
+             job_label=args.job_label,
+             pr_id=args.pr_id,
+             verbosity=args.verbosity)

--- a/ci/launch_e2e.sh
+++ b/ci/launch_e2e.sh
@@ -77,14 +77,8 @@ echo "(launch_e2e.sh) ==> The job type is $JOB_TYPE"
 echo "(launch_e2e.sh) ==> The ansible will be launched from $LAUNCH_FROM"
 echo "(launch_e2e.sh) ==> The ansible verbosity is $KUBEINIT_ANSIBLE_VERBOSITY"
 
-echo "(launch_e2e.sh) ==> Removing old tmp files ..."
-rm -rf tmp
-mkdir -p tmp
-cd tmp
-
 # Install the collection
 echo "(launch_e2e.sh) ==> Installing KubeInit ..."
-cd kubeinit
 rm -rf ~/.ansible/collections/ansible_collections/kubeinit/kubeinit
 ansible-galaxy collection build -v --force --output-path releases/
 ansible-galaxy collection install --force --force-with-deps releases/kubeinit-kubeinit-`cat galaxy.yml | shyaml get-value version`.tar.gz


### PR DESCRIPTION
This commit includes the --job_type=pr
in all the script calls for testing PRs.