### PR TITLE
docs: include all vars

### DIFF
--- a/docs/src/usage.rst
+++ b/docs/src/usage.rst
@@ -92,10 +92,18 @@ Deployment
 Group variables
 ---------------
 
+All
+^^^
+Default variables related to Ansible parameter, common
+across all the supported scenarios.
+
+.. autoyaml:: kubeinit/group_vars/all.yml
+
 Environment
 ^^^^^^^^^^^
-The following environmental variables can be used
+The following environment specific variables can be used
 with the deployment command.
+These variables might be specific to each scenario.
 
 .. autoyaml:: kubeinit/group_vars/kubeinit_env.yml
 
@@ -103,7 +111,8 @@ with the deployment command.
 Secrets
 ^^^^^^^
 
-Secrets are handled using the following variables.
+The common secrets supported across all the scenarios
+are handled using the following variables.
 
 .. autoyaml:: kubeinit/group_vars/kubeinit_secrets.yml
 

--- a/kubeinit/group_vars/all.yml
+++ b/kubeinit/group_vars/all.yml
@@ -1,8 +1,18 @@
 ---
 
-# Ansible vars
-ansible_python_interpreter: '/usr/bin/python3'
-ansible_ssh_pipelining: True
-ansible_ssh_common_args: '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=accept-new'
+#
+# Common variables
+#
 
+###
+# The default Python interpreter.
+ansible_python_interpreter: '/usr/bin/python3'
+###
+# If SSH pipelining is enabled by default.
+ansible_ssh_pipelining: True
+###
+# The default SSH common arguments.
+ansible_ssh_common_args: '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=accept-new'
+###
+# If Ansible debug is enabled by default.
 ansible_debug_enabled: "{{ (lookup('env','ANSIBLE_DEBUG') | bool) or false }}"

--- a/kubeinit/group_vars/kubeinit_env.yml
+++ b/kubeinit/group_vars/kubeinit_env.yml
@@ -17,16 +17,33 @@ docker_username: "{{ lookup('env','KUBEINIT_COMMON_DOCKER_USERNAME') | default(o
 # be used together.
 docker_password: "{{ lookup('env','KUBEINIT_COMMON_DOCKER_PASSWORD') | default(omit) }}"
 
-# Openshift deployment type and token info
+###
+# This variable configure if Openshift will be deployed.
 openshift_deploy: "{{ (lookup('env','KUBEINIT_COMMON_OPENSHIFT_DEPLOY') | bool) or false }}"
+###
+# OpenShift pullsecret.
 openshift_pullsecret: "{{ lookup('env','KUBEINIT_COMMON_OPENSHIFT_PULLSECRET') | default(omit) }}"
 
+###
+# Certificate default country.
 certificate_country: "{{ lookup('env','KUBEINIT_COMMON_CERTIFICATE_COUNTRY') or 'US' }}"
+###
+# Certificate default state.
 certificate_state: "{{ lookup('env','KUBEINIT_COMMON_CERTIFICATE_STATE') or 'MyState' }}"
+###
+# Certificate default locality.
 certificate_locality: "{{ lookup('env','KUBEINIT_COMMON_CERTIFICATE_LOCALITY') or 'MyCity' }}"
+###
+# Certificate default organization.
 certificate_organization: "{{ lookup('env','KUBEINIT_COMMON_CERTIFICATE_ORGANIZATION') or 'MyCompany' }}"
+###
+# Certificate default OU.
 certificate_organizational_unit: "{{ lookup('env','KUBEINIT_COMMON_CERTIFICATE_ORGANIZATIONAL_UNIT') or 'MyDepartment' }}"
 
+###
+# Default public DNS.
 dns_public: "{{ lookup('env','KUBEINIT_COMMON_DNS_PUBLIC') or '1.1.1.1' }}"
 
+###
+# Default SSH key type.
 ssh_keytype: "{{ lookup('env','KUBEINIT_COMMON_SSH_KEYTYPE') or 'rsa' }}"


### PR DESCRIPTION
This commit includes all group variables supported
to the docs automatically.