### PR TITLE
ci: remove int cast

### DIFF
--- a/ci/launch_e2e.py
+++ b/ci/launch_e2e.py
@@ -591,5 +591,5 @@ if __name__ == "__main__":
         main(job_type=args.job_type,
              cluster_type=args.cluster_type,
              job_label=args.job_label,
-             pr_id=int(args.pr_id),
+             pr_id=args.pr_id,
              verbosity=args.verbosity)


### PR DESCRIPTION
This commit removes a wrong cast
on the PR id, this variable might be int or
string.