### PR TITLE
ci: use nginx unprivileged in the sampleapp

### DIFF
--- a/kubeinit/roles/kubeinit_apps/templates/sampleapp.yml.j2
+++ b/kubeinit/roles/kubeinit_apps/templates/sampleapp.yml.j2
@@ -20,8 +20,6 @@ spec:
         # We try to avoid pulling from docker.io because
         # of the limit rate, this cause multiple installs
         # to fail that should be successful deployments
-        # TODO:FIXME: Find a more stable place like quay.io
-        # But there are no nginx official container images in quay
-        image: nginx:1.14.2
+        image: quay.io/packit/nginx-unprivileged
         ports:
-        - containerPort: 80
+        - containerPort: 8080


### PR DESCRIPTION
This commit pulls from quay (quay.io/packit/nginx-unprivileged)
the Nginx image to run the sample app.

This will run NGINX as a non root, unprivileged user.
Notable differences with respect to the official
NGINX image include:

- The default NGINX listen port is now 8080 instead of 80.
- The default NGINX user directive in /etc/nginx/nginx.conf has been removed.
- The default NGINX PID has been moved from /var/run/nginx.pid to /tmp/nginx.pid. *Change _temp_path variables to /tmp/.