### PR TITLE
ci: enable windows workers in the CI

### DIFF
--- a/ci/launch_e2e.sh
+++ b/ci/launch_e2e.sh
@@ -253,8 +253,13 @@ echo "(launch_e2e.sh) ==> Deploying the cluster ..."
 FAILED="0"
 KUBEINIT_SPEC=${KUBEINIT_SPEC//,/$'\n'}
 
-# For enabling Windows deployments use the cluster_nodes_spec like
-# -e cluster_nodes_spec='[[when_group=compute_nodes,os=windows]]' \
+# We enable having Windows compute nodes by default in the CI
+# for the k8s-1-1-1 spec scenario
+if [[ "$DISTRO" == "k8s" && "$MASTERS" == "1" &&  "$WORKERS" == "1" &&  "$HYPERVISORS" == "1" ]]; then
+    # For enabling Windows deployments use the cluster_nodes_spec like
+    # -e cluster_nodes_spec='[[when_group=compute_nodes,os=windows]]' \
+    CLUSTER_NODES='[[when_group=compute_nodes,os=windows]]'
+fi
 
 if [[ "$LAUNCH_FROM" == "h" ]]; then
     {
@@ -270,6 +275,7 @@ if [[ "$LAUNCH_FROM" == "h" ]]; then
                 -e post_deployment_services_spec='['${POST_DEPLOYMENT_SERVICES:-}']' \
                 -e kubeinit_network_spec='[network_name=kimgtnet'$COUNTER',network=10.0.'$COUNTER'.0/24]' \
                 -e hypervisor_hosts_spec='[[ansible_host=nyctea],[ansible_host=tyto]]' \
+                -e cluster_nodes_spec=${CLUSTER_NODES:-[[]]} \
                 ./kubeinit/playbook.yml
             # We can not have any other command after
             # 'ansible-playbook' otherwise the || wont work


### PR DESCRIPTION
This commit enables Windows workers in
the k8s-1-1-1 deployment spec for the CI.