### PR TITLE
ci: remove unsupported scenarios from CDK

### DIFF
--- a/ci/kubeinit_ci_utils.py
+++ b/ci/kubeinit_ci_utils.py
@@ -329,9 +329,9 @@ def get_periodic_jobs_labels(cluster_type='all', distro='all'):
     cluster_pattern = re.compile(cluster_type_regex)
 
     cdk_configs = ["cdk-libvirt-3-1-2-h",
-                   "cdk-libvirt-3-0-1-h",
+                   "cdk-libvirt-3-1-1-h",
                    "cdk-libvirt-1-1-1-h",
-                   "cdk-libvirt-1-0-1-h"]
+                   "cdk-libvirt-1-2-1-h"]
 
     okd_configs = ["okd-libvirt-3-1-1-h",
                    "okd-libvirt-3-0-2-h",


### PR DESCRIPTION
This commit allows to run workloads in
controller nodes when there are no
compute nodes.