### PR TITLE
ci: allow skipping upload logs to b2

### DIFF
--- a/ci/gitlab_ci_trigger.sh
+++ b/ci/gitlab_ci_trigger.sh
@@ -28,6 +28,7 @@ run_pr() {
     pr_list=$(gh pr list --json title,number,labels)
     ci_label_found=0
     ci_verbosity_label_found=0
+    ci_nolog_label_found=0
     test_params=''
     test_params+="--job_type=pr "
     pr_id="${pr_id:-0}"
@@ -45,7 +46,10 @@ run_pr() {
             else
                 label_regex=".*-.*-.*-.*-[^1]-.*"
             fi
+
             verbosity_regex="verbosity=.*"
+            nolog_regex='nolog'
+
             if [[ $label =~ $label_regex ]];then
                 echo "(gitlab_ci_trigger.sh) ==> There was found a job matching label: $label" ;
                 echo "(gitlab_ci_trigger.sh) ==> We assign the matching PR: $pr_number" ;
@@ -58,6 +62,10 @@ run_pr() {
             else
                 if [[ $label =~ $verbosity_regex ]]; then
                     test_params+="--${label} "
+                fi
+
+                if [[ $label =~ $nolog_regex ]]; then
+                    test_params+="--nolog "
                 fi
             fi
         done
@@ -117,6 +125,7 @@ main() {
     fi
 
     periodic_regex='periodic.*'
+
     if [[ $JOB_TYPE =~ $periodic_regex ]]; then
         echo "(gitlab_ci_trigger.sh) ==> Periodic job testing"
         get_code

--- a/ci/launch_e2e.py
+++ b/ci/launch_e2e.py
@@ -38,7 +38,7 @@ from pybadges import badge
 GH_LABELS = []
 
 
-def main(job_type, cluster_type, job_label, pr_id, verbosity):
+def main(job_type, cluster_type, job_label, pr_id, verbosity, nolog=False):
     """Run the main method."""
     #
     # This method can deploy multiple
@@ -133,9 +133,9 @@ def main(job_type, cluster_type, job_label, pr_id, verbosity):
             # If the main deployment failed, we dont need to capture
             # any other exception, this script must fail at the end
             if output == 1:
-                save_logs(output, job_name)
+                save_logs(output, job_name, nolog)
             else:
-                output = save_logs(output, job_name)
+                output = save_logs(output, job_name, nolog)
 
             dest_url = 'https://ci.kubeinit.org/file/kubeinit-ci/jobs/' + str(job_name) + "-" + str(output) + '/index.html'
             print("'launch_e2e.py' ==> The destination URL is: " + dest_url)
@@ -255,7 +255,7 @@ def main(job_type, cluster_type, job_label, pr_id, verbosity):
                                                                           state,
                                                                           str(start_time),
                                                                           dur_mins))
-                save_logs(output, job_name)
+                save_logs(output, job_name, nolog)
 
     #
     # KubeInit's submariner PR check
@@ -341,9 +341,9 @@ def main(job_type, cluster_type, job_label, pr_id, verbosity):
                     # If the main deployment failed, we dont need to capture
                     # any other exception, this script must fail at the end
                     if output == 1:
-                        save_logs(output, job_name)
+                        save_logs(output, job_name, nolog)
                     else:
-                        output = save_logs(output, job_name)
+                        output = save_logs(output, job_name, nolog)
 
                     dest_url = 'https://storage.googleapis.com/kubeinit-ci/jobs/' + str(job_name) + "-" + str(output) + '/index.html'
                     print("'launch_e2e.py' ==> Desc message: " + desc)
@@ -427,9 +427,11 @@ def run_e2e_job(distro, driver, masters, workers,
     return output
 
 
-def save_logs(output, job_name):
+def save_logs(output, job_name, nolog=False):
     """Save the e2e job logs."""
     print("'launch_e2e.py' ==> Rendering and saving the log files")
+    if nolog:
+        return 0
 
     initial_time = datetime.now()
     try:
@@ -566,6 +568,10 @@ if __name__ == "__main__":
                         action='store',
                         type=valid_labels_regex,
                         help='The CI job label to be executed')
+    parser.add_argument('--nolog',
+                        action='store_true',
+                        default=False,
+                        help='The CI job label to be executed')
 
     args = parser.parse_args()
     # The job type is a mandatory parameter
@@ -609,4 +615,5 @@ if __name__ == "__main__":
              cluster_type=args.cluster_type,
              job_label=args.job_label,
              pr_id=args.pr_id,
-             verbosity=args.verbosity)
+             verbosity=args.verbosity,
+             nolog=args.nolog)


### PR DESCRIPTION
This commit allows to use the nolog
label in the e2e jobs so the result is not uploaded
to b2. This is useful to reduce the load on the
CI CDN if there is no need to review the logs results.