### PR TITLE
feat: include dynamic extra roles

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,3 +7,4 @@ skip_list:
   - 'package-latest'  # [E403] Package installs should not use latest
   - 'var-spacing'
   - 'schema'
+  - 'git-latest'  # Git checkouts must contain explicit version.

--- a/ci/launch_e2e.sh
+++ b/ci/launch_e2e.sh
@@ -265,6 +265,7 @@ if [[ "$DISTRO" == "okd" && "$MASTERS" == "1" &&  "$WORKERS" == "1" &&  "$HYPERV
     # For enabling additional extra nodes use the extra_nodes_spec like
     # -e extra_nodes_spec='[{"name":"nova-compute","when_distro":["okd"],"os":"centos"}]'
     EXTRA_NODES='[{"name":"nova-compute","when_distro":["okd"],"os":"centos"}]'
+    EXTRA_ROLES='kubeinit_openstack'
 fi
 
 if [[ "$LAUNCH_FROM" == "h" ]]; then
@@ -279,6 +280,7 @@ if [[ "$LAUNCH_FROM" == "h" ]]; then
                 -e kubeinit_spec=${SPEC} \
                 -e kubeinit_libvirt_cloud_user_create=true \
                 -e post_deployment_services_spec='['${POST_DEPLOYMENT_SERVICES:-}']' \
+                -e extra_roles_spec='['${EXTRA_ROLES:-}']' \
                 -e kubeinit_network_spec='{"network_name":"kimgtnet'$COUNTER'","network":"10.0.'$COUNTER'.0/24"}' \
                 -e hypervisor_hosts_spec='[{"ansible_host":"nyctea"},{"ansible_host":"tyto"}]' \
                 -e cluster_nodes_spec=${CLUSTER_NODES:-[]} \

--- a/docs/src/roles/role-kubeinit_openstack.rst
+++ b/docs/src/roles/role-kubeinit_openstack.rst
@@ -1,0 +1,6 @@
+=========================
+Role - kubeinit_openstack
+=========================
+
+.. ansibleautoplugin::
+  :role: kubeinit/roles/kubeinit_openstack

--- a/kubeinit/inventory.yml
+++ b/kubeinit/inventory.yml
@@ -5,89 +5,89 @@
 
 all:
   children:
-###
-# The cluster's guest machines can be distributed across mutiple hosts. By default they
-# will be deployed in the first Hypervisor. These hypervisors are activated and used
-# depending on how they are referenced in the kubeinit spec string.
-#
-# When we are running the setup-playbook, if a hypervisor host has an ssh_hostname attribute
-# then a .ssh/config file will be created and an entry mapping the ansible_host to that
-# ssh hostname will be created. In the first example we would associate
-# the ansible_host of the first hypervisor host "nyctea" with the hostname provided, it
-# can be a short or fully qualified name, but it needs to be resolvable on the host we
-# are running the kubeinit setup from. The second example uses a host ip address, which
-# can be useful in those cases where the host you are using doesn't have a dns name.
-#
-# .. code-block:: yaml
-#
-#    hypervisor_hosts:
-#        hypervisor-01:
-#            ansible_host: nyctea
-#            ssh_hostname: server1.example.com
-#        hypervisor-02:
-#            ansible_host: tyto
-#            ssh_hostname: 192.168.222.202
+    ###
+    # The cluster's guest machines can be distributed across mutiple hosts. By default they
+    # will be deployed in the first Hypervisor. These hypervisors are activated and used
+    # depending on how they are referenced in the kubeinit spec string.
+    #
+    # When we are running the setup-playbook, if a hypervisor host has an ssh_hostname attribute
+    # then a .ssh/config file will be created and an entry mapping the ansible_host to that
+    # ssh hostname will be created. In the first example we would associate
+    # the ansible_host of the first hypervisor host "nyctea" with the hostname provided, it
+    # can be a short or fully qualified name, but it needs to be resolvable on the host we
+    # are running the kubeinit setup from. The second example uses a host ip address, which
+    # can be useful in those cases where the host you are using doesn't have a dns name.
+    #
+    # .. code-block:: yaml
+    #
+    #    hypervisor_hosts:
+    #        hypervisor-01:
+    #            ansible_host: nyctea
+    #            ssh_hostname: server1.example.com
+    #        hypervisor-02:
+    #            ansible_host: tyto
+    #            ssh_hostname: 192.168.222.202
     hypervisor_hosts:
       hosts:
         hypervisor-01:
           ansible_host: nyctea
         hypervisor-02:
           ansible_host: tyto
-###
-# The inventory will have one host identified as the bastion host. By default, this role will
-# be assumed by the first hyperviso. The example would set the second hypervisor to be the bastion host.
-# The final example would set the bastion host to be a different host that is not
-# being used as a hypervisor for the guests VMs for the clusters using this inventory.
-#
-# .. code-block:: yaml
-#
-#    bastion_host:
-#        bastion:
-#            ansible_host: hypervisor-02
-#
-# .. code-block:: yaml
-#
-#    bastion_host:
-#        bastion:
-#            ansible_host: bastion
+    ###
+    # The inventory will have one host identified as the bastion host. By default, this role will
+    # be assumed by the first hyperviso. The example would set the second hypervisor to be the bastion host.
+    # The final example would set the bastion host to be a different host that is not
+    # being used as a hypervisor for the guests VMs for the clusters using this inventory.
+    #
+    # .. code-block:: yaml
+    #
+    #    bastion_host:
+    #        bastion:
+    #            ansible_host: hypervisor-02
+    #
+    # .. code-block:: yaml
+    #
+    #    bastion_host:
+    #        bastion:
+    #            ansible_host: bastion
     bastion_host:
       hosts:
         bastion:
           target: hypervisor-01
-###
-# The inventory will have one host identified as the ovn-central host. By default, this role
-# will be assumed by the first hypervisor. The first example would set the second hypervisor
-# to be the ovn-central host.
-#
-# .. code-block:: yaml
-#
-#    ovn_central_host:
-#        target: hypervisor-02
+    ###
+    # The inventory will have one host identified as the ovn-central host. By default, this role
+    # will be assumed by the first hypervisor. The first example would set the second hypervisor
+    # to be the ovn-central host.
+    #
+    # .. code-block:: yaml
+    #
+    #    ovn_central_host:
+    #        target: hypervisor-02
     ovn_central_host:
       hosts:
         ovn-central:
           target: hypervisor-01
-###
-#
-# Setup host definition (used only with the setup-playbook.yml)
-#
-#
-# This inventory will have one host identified as the setup host. By default, this will be
-# localhost. The first example would set the first hypervisor host to be the setup host.
-# The last example would set the setup host to be a different host that is not being used
-# as a hypervisor in this inventory.
-#
-# .. code-block:: yaml
-#
-#    setup_host:
-#        ansible_host: nyctea
-#
-# or
-#
-# .. code-block:: yaml
-#
-#    setup_host:
-#        ansible_host: 192.168.222.214
+    ###
+    #
+    # Setup host definition (used only with the setup-playbook.yml)
+    #
+    #
+    # This inventory will have one host identified as the setup host. By default, this will be
+    # localhost. The first example would set the first hypervisor host to be the setup host.
+    # The last example would set the setup host to be a different host that is not being used
+    # as a hypervisor in this inventory.
+    #
+    # .. code-block:: yaml
+    #
+    #    setup_host:
+    #        ansible_host: nyctea
+    #
+    # or
+    #
+    # .. code-block:: yaml
+    #
+    #    setup_host:
+    #        ansible_host: 192.168.222.214
     setup_host:
       hosts:
         kubeinit-setup:

--- a/kubeinit/roles/kubeinit_openshift/tasks/post_deployment_tasks.yml
+++ b/kubeinit/roles/kubeinit_openshift/tasks/post_deployment_tasks.yml
@@ -167,3 +167,14 @@
   vars:
     kubeinit_deployment_node_name: "{{ kubeinit_provision_service_node }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
+
+#
+# Deploy extra roles
+#
+- name: Deploy extra roles
+  ansible.builtin.include_role:
+    name: "kubeinit.kubeinit.{{ extra_role }}"
+    public: yes
+  loop: "{{ kubeinit_cluster_hostvars['extra_roles'] | default([]) }}"
+  loop_control:
+    loop_var: extra_role

--- a/kubeinit/roles/kubeinit_openstack/README.md
+++ b/kubeinit/roles/kubeinit_openstack/README.md
@@ -1,0 +1,3 @@
+Please, refer to the kubeinit_openstack role
+[official docs](https://kubeinit.github.io/kubeinit/roles/role-kubeinit_openstack.html)
+for further information.

--- a/kubeinit/roles/kubeinit_openstack/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_openstack/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# All variables intended for modification should be placed in this file.
+
+# All variables within this role should have a prefix of "kubeinit_openstack_"
+kubeinit_openstack_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
+kubeinit_openstack_hide_sensitive_logs: true
+
+kubeinit_openstack_dependencies:
+  - git
+  - python3
+  - python3-pip
+  - gcc
+  - gcc-c++
+  - kernel-devel
+  - make

--- a/kubeinit/roles/kubeinit_openstack/handlers/main.yml
+++ b/kubeinit/roles/kubeinit_openstack/handlers/main.yml
@@ -1,0 +1,15 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.

--- a/kubeinit/roles/kubeinit_openstack/meta/main.yml
+++ b/kubeinit/roles/kubeinit_openstack/meta/main.yml
@@ -1,0 +1,44 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: KubeInit
+  role_name: kubeinit_openstack
+  namespace: kubeinit
+  description: KubeInit Role -- kubeinit_openstack
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.9
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - kubeinit
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/kubeinit/roles/kubeinit_openstack/molecule/default/converge.yml
+++ b/kubeinit/roles/kubeinit_openstack/molecule/default/converge.yml
@@ -1,0 +1,25 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+- name: Converge
+  hosts: all
+  # roles:
+  #   - role: "kubeinit_openstack"
+  tasks:
+    - name: Message for "kubeinit_openstack"
+      ansible.builtin.debug:
+        msg: Finishing molecule for "kubeinit_openstack"

--- a/kubeinit/roles/kubeinit_openstack/molecule/default/molecule.yml
+++ b/kubeinit/roles/kubeinit_openstack/molecule/default/molecule.yml
@@ -1,0 +1,13 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/kubeinit/roles/kubeinit_openstack/molecule/default/verify.yml
+++ b/kubeinit/roles/kubeinit_openstack/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    ansible.builtin.assert:
+      that: true

--- a/kubeinit/roles/kubeinit_openstack/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_openstack/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+#
+# "kubeinit_openstack" tasks
+#
+
+- name: Install the podified controlplane operators
+  ansible.builtin.include_tasks: podified_controlplane.yml
+
+- name: Run the standalone compute tasks
+  ansible.builtin.include_tasks: standalone_compute.yml
+  loop: "{{ groups['all_extra_nodes'] | default([]) }}"
+  loop_control:
+    loop_var: extra_node
+  when: "'nova' in extra_node"
+  vars:
+    kubeinit_deployment_node_name: "{{ extra_node }}"
+    tripleo_network_config_template: "templates/net_config_static_bridge.j2"
+    tripleo_network_config_hide_sensitive_logs: false
+    neutron_public_interface_name: "eth1"

--- a/kubeinit/roles/kubeinit_openstack/tasks/podified_controlplane.yml
+++ b/kubeinit/roles/kubeinit_openstack/tasks/podified_controlplane.yml
@@ -1,0 +1,64 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+#
+# "kubeinit_openstack" tasks
+#
+
+- name: Deploy the podified controlplane
+  block:
+
+    - name: Install CentOS based OpenStack dependencies
+      ansible.builtin.package:
+        name: "{{ kubeinit_openstack_dependencies }}"
+        state: present
+
+    - name: Checkout latest openstack-k8s-operators install_yamls code
+      ansible.builtin.git:
+        repo: "https://github.com/ccamacho/install_yamls.git"
+        dest: "/src/install_yamls"
+
+    - name: Run install_yamls
+      ansible.builtin.shell: |
+        set -o pipefail
+
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+        mv ./kustomize /bin/
+
+        cd /src/install_yamls
+
+        # one time operation to initialize PVs within the CRC VM
+        make crc_storage &
+
+        # Install MariaDB Operator using OLM (defaults to quay.io/openstack-k8s-operators)
+        make mariadb MARIADB_IMG=quay.io/openstack-k8s-operators/mariadb-operator-index:latest &
+
+        # Install Keystone Operator using OLM (defaults to quay.io/openstack-k8s-operators)
+        make keystone KEYSTONE_IMG=quay.io/openstack-k8s-operators/keystone-operator-index:latest &
+
+        # Deploy MariaDB CRs
+        make mariadb_deploy &
+
+        # Deploy Keystone CRs
+        make keystone_deploy &
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+  vars:
+    kubeinit_deployment_node_name: "{{ kubeinit_provision_service_node }}"
+  delegate_to: "{{ kubeinit_deployment_node_name }}"

--- a/kubeinit/roles/kubeinit_openstack/tasks/standalone_compute.yml
+++ b/kubeinit/roles/kubeinit_openstack/tasks/standalone_compute.yml
@@ -1,0 +1,83 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+#
+# "kubeinit_openstack" tasks
+#
+
+- name: Run the deployment tasks in each extra node (those extra nodes having the 'nova' string)
+  block:
+
+    - name: Install CentOS based OpenStack dependencies
+      ansible.builtin.package:
+        name: "{{ kubeinit_openstack_dependencies }}"
+        state: present
+
+    - name: Checkout latest ooo Ansible code
+      ansible.builtin.git:
+        repo: "https://opendev.org/openstack/tripleo-ansible.git"
+        dest: "/src/tripleo-ansible"
+
+    - name: Install Ansible
+      ansible.builtin.shell: |
+        set -o pipefail
+        pip3 install ansible
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+
+    - name: Get the tripleo-ansible standalone WIP code
+      ansible.builtin.shell: |
+        set -o pipefail
+
+        cd /src/tripleo-ansible
+        gerrit_patch=840509
+        # We get the latest change given a gerrit review
+        change=$(git ls-remote https://review.opendev.org/openstack/tripleo-ansible | grep ${gerrit_patch} | cut -f2 -d$'\t' | sort -t / -k 5 -g -r | head -n 1)
+        echo ${change}
+
+        # We fetch the change
+        git fetch https://review.opendev.org/openstack/tripleo-ansible ${change} && git checkout FETCH_HEAD
+
+        # I didnt find a way to get the gerrit change given the changeid
+        # Now we need to pull all the depends on changes
+        ## dependson=$(git --no-pager log -n1 | grep 'Depends-On:' | tr -s " " | cut -f3 -d' ')
+
+        dependson="840675 841795 841996 841997 842150 842234 842437 842152"
+
+        for d in ${dependson}; do
+            echo ${d}
+            change=$(git ls-remote https://review.opendev.org/openstack/tripleo-ansible | grep ${d} | cut -f2 -d$'\t' | sort -t / -k 5 -g -r | head -n 1)
+            echo ${change}
+            git fetch https://review.opendev.org/openstack/tripleo-ansible ${change} && git cherry-pick FETCH_HEAD
+        done
+
+        # TODO:FIXME:
+        # I should be able to install this tripleo-ansible
+        # as a galaxy requirement to fetch and delegate correctly
+        # the tasks execution.
+        ansible-galaxy install --force -r requirements.yml
+        export ANSIBLE_ROLES_PATH=/src/tripleo-ansible/tripleo_ansible/roles
+        export ANSIBLE_LIBRARY=/src/tripleo-ansible/tripleo_ansible/ansible_plugins/modules/
+        ansible-playbook -i tripleo_ansible/inventory/02-compute ./tripleo_ansible/playbooks/deploy-overcloud-compute.yaml
+      args:
+        executable: /bin/bash
+      register: _result
+      changed_when: "_result.rc == 0"
+
+  delegate_to: "{{ kubeinit_deployment_node_name }}"

--- a/kubeinit/roles/kubeinit_openstack/vars/main.yml
+++ b/kubeinit/roles/kubeinit_openstack/vars/main.yml
@@ -1,0 +1,22 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "kubeinit_openstack_"

--- a/kubeinit/roles/kubeinit_prepare/tasks/build_hypervisors_group.yml
+++ b/kubeinit/roles/kubeinit_prepare/tasks/build_hypervisors_group.yml
@@ -166,6 +166,18 @@
     post_deployment_services: "{{ post_deployment_services_list }}"
   when: post_deployment_services_list | default([]) | length > 0
 
+- name: Load extra_roles_spec from yaml into a list
+  ansible.builtin.set_fact:
+    extra_roles_list: "{{ extra_roles_spec | from_yaml }}"
+  when: extra_roles_spec is defined
+
+- name: Add extra_roles_list to kubeinit_cluster group
+  ansible.builtin.add_host:
+    name: "{{ kubeinit_cluster_name }}"
+    groups: 'kubeinit_cluster'
+    extra_roles: "{{ extra_roles_list }}"
+  when: extra_roles_list | default([]) | length > 0
+
 - name: Assert that we have enough hypervisors defined for this cluster if they are provided by the inventory
   ansible.builtin.assert:
     msg: "Your kubeinit_spec needs {{ kubeinit_spec_hypervisor_count|int }} hypervisor hosts and your inventory only defines {{ groups['hypervisor_hosts'] | length }}."


### PR DESCRIPTION
This commit includes the ability to
run custom roles at the end of the
deployments. As an example we run a
custom openstack role.