### PR TITLE
fix: add qcow2 full path deploying coreos as guest

### DIFF
--- a/kubeinit/roles/kubeinit_libvirt/tasks/deploy_coreos_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/deploy_coreos_guest.yml
@@ -36,7 +36,7 @@
             --os-variant=fedora29 \
             --autostart \
             --network network={{ kubeinit_cluster_hostvars.network_name }},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }},target.dev=veth0-{{ hostvars[kubeinit_deployment_node_name].ansible_host | ansible.netcommon.ip4_hex }},model=virtio \
-            --disk size={{ hostvars[kubeinit_deployment_node_name].disk | replace('G','') }},readonly=false \
+            --disk {{ kubeinit_libvirt_target_image_dir }}/{{ hostvars[kubeinit_deployment_node_name].guest_name }}.qcow2,format=qcow2,bus=virtio,size={{ hostvars[kubeinit_deployment_node_name].disk | replace('G','') }},readonly=false \
             --location {{ kubeinit_libvirt_target_image_dir }}/ \
             --extra-args "${kernel_args}"
       args:


### PR DESCRIPTION
Currently defining the VM on the deploy_coreos_guest task does
not add the path of the qcow2 disk. This makes the variable
kubeinit_libvirt_target_image_dir useless.

This patch add the path to the disk in the same way as is defined
on the deploy_centos_guest task.