### PR TITLE
fix: remove ansible-playbook-grapher workaround

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -42,10 +42,6 @@ jobs:
           sudo python3 -m pip install --upgrade sphinx
           sudo python3 -m pip install --upgrade sphinx-rtd-theme
           sudo python3 -m pip install --upgrade yq
-          git clone https://github.com/haidaraM/ansible-playbook-grapher.git
-          cd ansible-playbook-grapher
-          python3 -m pip install -r requirements.txt
-          python3 -m pip install --upgrade --force .
 
       - name: Install kubeinit's collection
         run: |


### PR DESCRIPTION
This commit removes the workaround for
the issue building the docs site.