### PR TITLE
feat: include OpenStack deployment driver

### DIFF
--- a/ci/ansible/roles/kubeinit_ci/tasks/gather_ci_facts.yml
+++ b/ci/ansible/roles/kubeinit_ci/tasks/gather_ci_facts.yml
@@ -106,7 +106,7 @@
 
 - name: Define kubeinit_ci_host_name
   ansible.builtin.set_fact:
-    kubeinit_ci_host_name: "{{ ci_host_map['host'] | default('kubeinit-ci' }}"
+    kubeinit_ci_host_name: "{{ ci_host_map['host'] | default('kubeinit-ci') }}"
 
 - name: Define kubeinit_ci_ansible_host
   ansible.builtin.set_fact:

--- a/ci/launch_e2e.sh
+++ b/ci/launch_e2e.sh
@@ -265,8 +265,8 @@ if [[ "$DISTRO" == "okd" && "$MASTERS" == "1" &&  "$WORKERS" == "1" &&  "$HYPERV
     # For enabling additional extra nodes use the extra_nodes_spec like
     # -e extra_nodes_spec='[{"name":"nova-compute","when_distro":["okd"],"os":"centos"}]'
     EXTRA_NODES='[{"name":"nova-compute","when_distro":["okd"],"os":"centos"}]'
-    EXTRA_ROLES='kubeinit_openstack'
-    EXTRA_VARS='-e kubeinit_openstack_deploy_standalone=true'
+    EXTRA_ROLES='kubeinit_ooonextgen'
+    EXTRA_VARS='-e kubeinit_ooonextgen_deploy_standalone=true'
 fi
 
 if [[ "$LAUNCH_FROM" == "h" ]]; then

--- a/docs/src/roles/role-kubeinit_ooonextgen.rst
+++ b/docs/src/roles/role-kubeinit_ooonextgen.rst
@@ -1,0 +1,6 @@
+=========================
+Role - kubeinit_ooonextgen
+=========================
+
+.. ansibleautoplugin::
+  :role: kubeinit/roles/kubeinit_ooonextgen

--- a/kubeinit/roles/kubeinit_libvirt/tasks/70_check_nodes_up.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/70_check_nodes_up.yml
@@ -18,7 +18,7 @@
 # Verify that nodes are up before continuing
 #
 
-- name: "make sure we can execute remote commands in {{ kubeinit_deployment_node_name }} before continue"
+- name: "Make sure we can execute remote commands in {{ kubeinit_deployment_node_name }} before continue"
   ansible.builtin.shell: |
     set -o pipefail
     ssh {{ hostvars[kubeinit_deployment_node_name].ansible_ssh_common_args }} \

--- a/kubeinit/roles/kubeinit_ooonextgen/README.md
+++ b/kubeinit/roles/kubeinit_ooonextgen/README.md
@@ -1,0 +1,3 @@
+Please, refer to the kubeinit_ooonextgen role
+[official docs](https://kubeinit.github.io/kubeinit/roles/role-kubeinit_ooonextgen.html)
+for further information.

--- a/kubeinit/roles/kubeinit_ooonextgen/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/defaults/main.yml
@@ -15,6 +15,20 @@
 # under the License.
 
 
-#
-# "kubeinit_openstack" tasks
-#
+# All variables intended for modification should be placed in this file.
+
+# All variables within this role should have a prefix of "kubeinit_ooonextgen_"
+kubeinit_ooonextgen_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
+kubeinit_ooonextgen_hide_sensitive_logs: true
+
+kubeinit_ooonextgen_dependencies:
+  - git
+  - python3
+  - python3-pip
+  - gcc
+  - gcc-c++
+  - kernel-devel
+  - make
+
+kubeinit_ooonextgen_deploy_podified: false
+kubeinit_ooonextgen_deploy_standalone: false

--- a/kubeinit/roles/kubeinit_ooonextgen/handlers/main.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/handlers/main.yml
@@ -13,8 +13,3 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
-
-#
-# "kubeinit_openstack" tasks
-#

--- a/kubeinit/roles/kubeinit_ooonextgen/meta/main.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/meta/main.yml
@@ -1,0 +1,44 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+galaxy_info:
+  author: KubeInit
+  role_name: kubeinit_ooonextgen
+  namespace: kubeinit
+  description: KubeInit Role -- kubeinit_ooonextgen
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: 2.9
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  platforms:
+    - name: CentOS
+      versions:
+        - 7
+        - 8
+
+  galaxy_tags:
+    - kubeinit
+
+
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+dependencies: []

--- a/kubeinit/roles/kubeinit_ooonextgen/molecule/default/converge.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/molecule/default/converge.yml
@@ -15,6 +15,11 @@
 # under the License.
 
 
-#
-# "kubeinit_openstack" tasks
-#
+- name: Converge
+  hosts: all
+  # roles:
+  #   - role: "kubeinit_ooonextgen"
+  tasks:
+    - name: Message for "kubeinit_ooonextgen"
+      ansible.builtin.debug:
+        msg: Finishing molecule for "kubeinit_ooonextgen"

--- a/kubeinit/roles/kubeinit_ooonextgen/molecule/default/molecule.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/molecule/default/molecule.yml
@@ -1,0 +1,13 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/kubeinit/roles/kubeinit_ooonextgen/molecule/default/verify.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    ansible.builtin.assert:
+      that: true

--- a/kubeinit/roles/kubeinit_ooonextgen/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+# Copyright kubeinit contributors
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+#
+# "kubeinit_ooonextgen" tasks
+#
+
+#
+# This tasks files can deploy a standalone TripleO node
+# in the extra node attached to the OpenShift cluster
+# or the podified control plane services
+#
+# A potential new usecase might be having two extra nodes
+# one node with the standalone TripleO and another that will
+# get the Nova compute services.
+#
+
+#
+# Install standalone TripleO
+#
+
+- name: Install standalone Tripleo
+  ansible.builtin.include_tasks: standalone_tripleo.yml
+  loop: "{{ groups['all_extra_nodes'] | default([]) }}"
+  loop_control:
+    loop_var: extra_node
+  when: "'nova' in extra_node and kubeinit_ooonextgen_deploy_standalone | default(false)"
+  vars:
+    kubeinit_deployment_node_name: "{{ extra_node }}"
+    tripleo_network_config_template: "templates/net_config_static_bridge.j2"
+    tripleo_network_config_hide_sensitive_logs: false
+    neutron_public_interface_name: "eth1"
+
+#
+# Install podified control plane
+#
+
+- name: Install the podified controlplane operators
+  ansible.builtin.include_tasks: podified_controlplane.yml
+  when: kubeinit_ooonextgen_deploy_podified | default(false)
+
+- name: Run the standalone compute tasks
+  ansible.builtin.include_tasks: standalone_compute.yml
+  loop: "{{ groups['all_extra_nodes'] | default([]) }}"
+  loop_control:
+    loop_var: extra_node
+  when: "'nova' in extra_node and kubeinit_ooonextgen_deploy_podified | default(false)"
+  vars:
+    kubeinit_deployment_node_name: "{{ extra_node }}"
+    tripleo_network_config_template: "templates/net_config_static_bridge.j2"
+    tripleo_network_config_hide_sensitive_logs: false
+    neutron_public_interface_name: "eth1"

--- a/kubeinit/roles/kubeinit_ooonextgen/tasks/podified_controlplane.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/tasks/podified_controlplane.yml
@@ -16,7 +16,7 @@
 
 
 #
-# "kubeinit_openstack" tasks
+# "kubeinit_ooonextgen" tasks
 #
 
 - name: Deploy the podified controlplane
@@ -24,7 +24,7 @@
 
     - name: Install CentOS based OpenStack dependencies
       ansible.builtin.package:
-        name: "{{ kubeinit_openstack_dependencies }}"
+        name: "{{ kubeinit_ooonextgen_dependencies }}"
         state: present
 
     - name: Checkout latest openstack-k8s-operators install_yamls code

--- a/kubeinit/roles/kubeinit_ooonextgen/tasks/standalone_compute.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/tasks/standalone_compute.yml
@@ -16,7 +16,7 @@
 
 
 #
-# "kubeinit_openstack" tasks
+# "kubeinit_ooonextgen" tasks
 #
 
 - name: Run the deployment tasks in each extra node (those extra nodes having the 'nova' string)
@@ -24,7 +24,7 @@
 
     - name: Install CentOS based OpenStack dependencies
       ansible.builtin.package:
-        name: "{{ kubeinit_openstack_dependencies }}"
+        name: "{{ kubeinit_ooonextgen_dependencies }}"
         state: present
 
     - name: Checkout latest ooo Ansible code

--- a/kubeinit/roles/kubeinit_ooonextgen/tasks/standalone_tripleo.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/tasks/standalone_tripleo.yml
@@ -16,7 +16,7 @@
 
 
 #
-# "kubeinit_openstack" tasks
+# "kubeinit_ooonextgen" tasks
 #
 
 - name: Run the deployment tasks in each extra node (those extra nodes having the 'nova' string)
@@ -24,7 +24,7 @@
 
     - name: Install CentOS based OpenStack dependencies
       ansible.builtin.package:
-        name: "{{ kubeinit_openstack_dependencies }}"
+        name: "{{ kubeinit_ooonextgen_dependencies }}"
         state: present
 
     - name: Create the stack user

--- a/kubeinit/roles/kubeinit_ooonextgen/vars/main.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/vars/main.yml
@@ -15,6 +15,8 @@
 # under the License.
 
 
-#
-# "kubeinit_openstack" tasks
-#
+# While options found within the vars/ path can be overridden using extra
+# vars, items within this path are considered part of the role and not
+# intended to be modified.
+
+# All variables within this role should have a prefix of "kubeinit_ooonextgen_"

--- a/kubeinit/roles/kubeinit_openshift/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_openshift/tasks/main.yml
@@ -144,7 +144,7 @@
 - name: Complete the cluster deployment on the provision service node
   block:
 
-    - name: "wait until all nodes are ready"
+    - name: Wait until all nodes are ready
       ansible.builtin.shell: |
         set -o pipefail
         export KUBECONFIG=~/install_dir/auth/kubeconfig; \

--- a/kubeinit/roles/kubeinit_openstack/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_openstack/defaults/main.yml
@@ -20,15 +20,3 @@
 # All variables within this role should have a prefix of "kubeinit_openstack_"
 kubeinit_openstack_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
 kubeinit_openstack_hide_sensitive_logs: true
-
-kubeinit_openstack_dependencies:
-  - git
-  - python3
-  - python3-pip
-  - gcc
-  - gcc-c++
-  - kernel-devel
-  - make
-
-kubeinit_openstack_deploy_podified: false
-kubeinit_openstack_deploy_standalone: false


### PR DESCRIPTION
This commit includes the folder to add a new deployment driver,
as for now deployments are only supported on KVM hosts.
The previous openstack role is renamed to be consumed as a user
application.