### PR TITLE
fix: remove update from customize

### DIFF
--- a/kubeinit/roles/kubeinit_libvirt/tasks/deploy_centos_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/deploy_centos_guest.yml
@@ -53,7 +53,6 @@
     - name: "Inject virt-customize assets in {{ kubeinit_deployment_node_name }}"
       ansible.builtin.shell: |
         virt-customize -a {{ kubeinit_libvirt_target_image_dir }}/{{ hostvars[kubeinit_deployment_node_name].guest_name }}.qcow2 \
-          --update \
           --install python3 \
           --run-command "sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config" \
           --run-command "ssh-keygen -A" \
@@ -80,12 +79,12 @@
       ansible.builtin.shell: |
         virt-install \
             --connect qemu:///system \
-            --name={{ hostvars[kubeinit_deployment_node_name].guest_name }} \
+            --name {{ hostvars[kubeinit_deployment_node_name].guest_name }} \
             --memory memory={{ hostvars[kubeinit_deployment_node_name].ram|int // 1024 }} \
-            --cpuset=auto \
-            --vcpus={{ hostvars[kubeinit_deployment_node_name].vcpus }},maxvcpus={{ hostvars[kubeinit_deployment_node_name].maxvcpus }} \
-            --os-type=linux \
-            --os-variant=rhel8.0 \
+            --cpuset auto \
+            --vcpus {{ hostvars[kubeinit_deployment_node_name].vcpus }},maxvcpus={{ hostvars[kubeinit_deployment_node_name].maxvcpus }} \
+            --os-type linux \
+            --os-variant rhel8.0 \
             --autostart \
             --network network={{ kubeinit_cluster_hostvars.network_name }},mac={{ hostvars[kubeinit_deployment_node_name].mac }},virtualport.parameters.interfaceid={{ hostvars[kubeinit_deployment_node_name].interfaceid }},target.dev=veth0-{{ hostvars[kubeinit_deployment_node_name].ansible_host | ansible.netcommon.ip4_hex }},model=virtio \
             --graphics none \

--- a/kubeinit/roles/kubeinit_libvirt/tasks/download_cloud_images.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/download_cloud_images.yml
@@ -84,6 +84,10 @@
     cloud_image: "{{ item[1] }}"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
 
+#
+# TODO:FIXME: Make sure the kernel update do not break the Guest from booting
+#
+
 - name: Update packages in cloud images
   ansible.builtin.command: |
     virt-customize -a {{ kubeinit_libvirt_target_image_dir }}/{{ cloud_image.image }} {% if (kubeinit_cluster_distro == 'cdk' or kubeinit_cluster_distro == 'rke') %}--run-command 'env DEBIAN_FRONTEND=noninteractive apt-get -y --allow-remove-essential purge shim-signed'{% endif %} --update
@@ -94,6 +98,8 @@
   register: _result
   changed_when: "_result.rc == 0"
   delegate_to: "{{ kubeinit_deployment_node_name }}"
+  # This is dangerous,do not run packages upgrades with virt-customize
+  when: false
 
 #
 # Download extra cloud images for Windows compute nodes or any miscelaneous image requirement


### PR DESCRIPTION
This commit removes the update shortcut from
the virt-customize command when deploying
Stream 9 images.