### PR TITLE
fix: include the python tripleo client

### DIFF
--- a/kubeinit/roles/kubeinit_ooonextgen/tasks/standalone_tripleo.yml
+++ b/kubeinit/roles/kubeinit_ooonextgen/tasks/standalone_tripleo.yml
@@ -49,6 +49,8 @@
         rpm_name=$(curl $url | grep python3-tripleo-repos | sed -e 's/<[^>]*>//g' | awk 'BEGIN { FS = ".rpm" } ; { print $1 }')
         rpm=$rpm_name.rpm
         dnf install -y $url$rpm
+        tripleo-repos current-tripleo-dev
+        dnf install -y python3-tripleoclient
       args:
         executable: /bin/bash
       register: _result


### PR DESCRIPTION
This commit includes again the python tripleo client to deploy the standalone node