### PR TITLE
fix: change docker.io by quay.io

### DIFF
--- a/kubeinit/roles/kubeinit_apache/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_apache/tasks/main.yml
@@ -20,7 +20,7 @@
     name: "buildah"
 
 - name: Create a new working container image
-  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-apache docker.io/httpd:2.4
+  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-apache quay.io/jlarriba/httpd:2.4
   register: _result
   changed_when: "_result.rc == 0"
 

--- a/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_haproxy/tasks/main.yml
@@ -44,7 +44,7 @@
   changed_when: "_result.rc == 0"
 
 - name: Create a new working container image
-  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-haproxy docker.io/library/haproxy:2.3
+  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-haproxy quay.io/jlarriba/haproxy:2.3
   register: _result
   changed_when: "_result.rc == 0"
 

--- a/kubeinit/roles/kubeinit_registry/tasks/main.yml
+++ b/kubeinit/roles/kubeinit_registry/tasks/main.yml
@@ -20,7 +20,7 @@
     name: "buildah"
 
 - name: Create a new working container image
-  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-registry docker.io/library/registry:2
+  ansible.builtin.command: buildah from --name {{ kubeinit_cluster_name }}-registry quay.io/jlarriba/registry:2
   register: _result
   changed_when: "_result.rc == 0"
 


### PR DESCRIPTION
This commit reduces the number of references
to docker.io to avoid the limit-rate issue.