### PR TITLE
ci: use rsvg-convert for docs

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y \
+                               librsvg2-bin \
                                ghostscript \
                                libfreetype6-dev \
                                gsfonts \
@@ -89,7 +90,8 @@ jobs:
           for diagram in *.svg; do
               echo "Rendering $diagram"
               dest=`echo "$diagram" | cut -d'.' -f1`
-              convert "$diagram" "$dest.png"
+              # convert "$diagram" "$dest.png"
+              rsvg-convert "$diagram" > "$dest.png"
           done
           cd ../../../../
           echo " "


### PR DESCRIPTION
This commit changes the tool
used for rendering the PNG images
from the SVG sources in the documentation.