### PR TITLE
ci: sync up containers on push

### DIFF
--- a/.github/workflows/quay_mirror.yml
+++ b/.github/workflows/quay_mirror.yml
@@ -3,6 +3,9 @@
 # images from docker.io to quay.io
 name: quay_mirror
 on:
+  push:
+    branches:
+      - main
   # Run the mirror every week
   schedule:
     - cron: '0 0 * * 0'


### PR DESCRIPTION
This commit makes the container mirror
script to run in evrey push.