### PR TITLE
fix: run EKS with the latest revision available

### DIFF
--- a/kubeinit/roles/kubeinit_eks/tasks/post_configure_guest.yml
+++ b/kubeinit/roles/kubeinit_eks/tasks/post_configure_guest.yml
@@ -120,7 +120,10 @@
     state: present
 
 - name: Install requirements
-  ansible.builtin.command: dnf install -y kubelet-{{ kubeinit_eks_kubernetes_version + '.' + kubeinit_eks_revision }} kubeadm-{{ kubeinit_eks_kubernetes_version + '.' + kubeinit_eks_revision }} kubectl-{{ kubeinit_eks_kubernetes_version + '.' + kubeinit_eks_revision }} --disableexcludes=kubernetes
+  # TODO:FIXME: The minor version here (revision) does not match with the packages versions from the kubernetes.repo
+  # EKS always have a higher revision available than the main package repository.
+  # ansible.builtin.command: dnf install -y kubelet-{{ kubeinit_eks_kubernetes_version + '.' + kubeinit_eks_revision }} kubeadm-{{ kubeinit_eks_kubernetes_version + '.' + kubeinit_eks_revision }} kubectl-{{ kubeinit_eks_kubernetes_version + '.' + kubeinit_eks_revision }} --disableexcludes=kubernetes
+  ansible.builtin.command: dnf install -y kubelet-{{ kubeinit_eks_kubernetes_version }}.* kubeadm-{{ kubeinit_eks_kubernetes_version }}.* kubectl-{{ kubeinit_eks_kubernetes_version }}.* --disableexcludes=kubernetes
   register: _result
   changed_when: "_result.rc == 0"
 

--- a/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
+++ b/kubeinit/roles/kubeinit_libvirt/defaults/main.yml
@@ -64,8 +64,10 @@ kubeinit_libvirt_cloud_images:
     uri: "https://cloud.centos.org/centos/9-stream/x86_64/images/"
     image: "CentOS-Stream-GenericCloud-9-{{ kubeinit_libvirt_centos_release }}.x86_64.qcow2"
 
-kubeinit_libvirt_virtio_folder_name: 'virtio-win-0.1.229-1'
-kubeinit_libvirt_virtio_image_name: 'virtio-win-0.1.229.iso'
+kubeinit_libvirt_virtio_version: "virtio-win-0.1.229"
+kubeinit_libvirt_virtio_image_format: 'iso'
+kubeinit_libvirt_virtio_folder_name: "{{ kubeinit_libvirt_virtio_version }}-1"
+kubeinit_libvirt_virtio_image_name: "{{ kubeinit_libvirt_virtio_version }}.{{ kubeinit_libvirt_virtio_image_format }}"
 
 kubeinit_libvirt_extra_cloud_images:
   - description: 'Windows Server 2022 preview (EVAL)'


### PR DESCRIPTION
This commit makes sure the installer gets
the latest revision available.