### PR TITLE
fix: allow unsecure Kubernetes repos

### DIFF
--- a/kubeinit/roles/kubeinit_libvirt/tasks/deploy_ubuntu_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/deploy_ubuntu_guest.yml
@@ -122,8 +122,11 @@
         set -eo pipefail
         apt-get install -y apt-transport-https ca-certificates curl
         curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
-        echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
-        apt-get update
+        echo "deb [trusted=yes igned-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+        apt-get update --allow-insecure-repositories
+      args:
+
+
       args:
         executable: /bin/bash
       register: _result


### PR DESCRIPTION
This commit make sure the official K8s repos
are trusted.