### PR TITLE
fix: removeduplicated key

### DIFF
--- a/kubeinit/roles/kubeinit_libvirt/tasks/deploy_ubuntu_guest.yml
+++ b/kubeinit/roles/kubeinit_libvirt/tasks/deploy_ubuntu_guest.yml
@@ -125,9 +125,6 @@
         echo "deb [trusted=yes igned-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
         apt-get update --allow-insecure-repositories
       args:
-
-
-      args:
         executable: /bin/bash
       register: _result
       changed_when: "_result.rc == 0"


### PR DESCRIPTION
This commit fixes a duplicated key nit in the
libvirt driver role.