### PR TITLE
ci: remove extra ansible arguments

### DIFF
--- a/molecule/run.sh
+++ b/molecule/run.sh
@@ -23,7 +23,6 @@ set -xeuo
 
 ## Vars ----------------------------------------------------------------------
 export PROJECT_DIR=${PWD}
-export KUBEINIT_JOB_ANSIBLE_ARGS=${KUBEINIT_JOB_ANSIBLE_ARGS:-"-vvvvv"}
 export ANSIBLE_REMOTE_TMP=/tmp/$USER/ansible
 
 if [ ! -f tox.ini ]; then
@@ -62,7 +61,6 @@ PS1="[\u@\h \W]\$" source "${HOME}/test-python/bin/activate"
 cd ./kubeinit/roles/
 python3 -m pytest \
         --trace \
-        --ansible-args=${KUBEINIT_JOB_ANSIBLE_ARGS} \
         --color=no \
         --html=/tmp/reports.html \
         --self-contained-html


### PR DESCRIPTION
This commit removes the extra argument passed in pytest when running the molecule testing suite.