### PR TITLE
fix: fix subnet path for /etc/cni/net.d/87-podman-bridge.conflist

### DIFF
--- a/kubeinit/roles/kubeinit_k8s/tasks/post_configure_guest.yml
+++ b/kubeinit/roles/kubeinit_k8s/tasks/post_configure_guest.yml
@@ -48,7 +48,7 @@
         # Make sure crio binary is reachable
         ln -s /usr/bin/crio /usr/local/bin/crio
         tmp=$(mktemp)
-        jq '.ipam.ranges[0][0].subnet = "{{ kubeinit_k8s_pod_network }}/{{ kubeinit_k8s_pod_subnet_len }}"' /etc/cni/net.d/87-crio-bridge.conflist > "$tmp" && mv -f "$tmp" /etc/cni/net.d/87-crio-bridge.conflist
+        jq '.plugins[0].ipam.ranges[0][0].subnet = "{{ kubeinit_k8s_pod_network }}/{{ kubeinit_k8s_pod_subnet_len }}"' /etc/cni/net.d/87-crio-bridge.conflist > "$tmp" && mv -f "$tmp" /etc/cni/net.d/87-crio-bridge.conflist
         # jq '.type = "flannel"' /etc/cni/net.d/87-crio-bridge.conf > "$tmp" && mv -f "$tmp" /etc/cni/net.d/87-crio-bridge.conf
         # rm -rf /etc/cni/net.d/87-crio-bridge.conf
         # echo '{"name": "crio","type": "flannel"}' > /etc/cni/net.d/10-crio.conf


### PR DESCRIPTION
This commit fixes the current path for the subnet in /etc/cni/net.d/87-podman-bridge.conflist