### PR TITLE
fix: string in revision error PEP 440

### DIFF
--- a/ci/gitlab_merge_request.sh
+++ b/ci/gitlab_merge_request.sh
@@ -92,7 +92,7 @@ export ARA_API_SERVER="http://127.0.0.1:8000"
 # Install the CLI/agent
 #
 python3 -m pip install -r ./agent/requirements.txt
-KUBEINIT_REVISION="${revision:-ci}" python3 -m pip install --upgrade ./agent
+KUBEINIT_REVISION="${revision:-99}" python3 -m pip install --upgrade ./agent
 
 KUBEINIT_SPEC=$KUBEINIT_SPEC_LABEL
 

--- a/ci/launch_e2e.sh
+++ b/ci/launch_e2e.sh
@@ -162,7 +162,7 @@ podman exec -it api-server /bin/bash -c "ara-manage migrate"
 # Install the CLI/agent
 #
 python3 -m pip install -r ./agent/requirements.txt
-KUBEINIT_REVISION="${revision:-ci}" python3 -m pip install --upgrade ./agent
+KUBEINIT_REVISION="${revision:-99}" python3 -m pip install --upgrade ./agent
 
 export KUBEINIT_COMMON_DNS_PUBLIC='10.11.5.160'
 


### PR DESCRIPTION
The version specified is not a valid version according to PEP 440. This may not work as expected with newer versions of setuptools, pip, and PyPI.