### PR TITLE
fix: use the correct socket service

### DIFF
--- a/kubeinit/roles/kubeinit_rke/tasks/post_configure_guest.yml
+++ b/kubeinit/roles/kubeinit_rke/tasks/post_configure_guest.yml
@@ -25,13 +25,6 @@
     name: "docker.io"
     state: present
 
-- name: Enable and start podman.socket
-  ansible.builtin.systemd:
-    name: podman.socket
-    enabled: yes
-    state: started
-    scope: user
-
 - name: Install kubectl
   ansible.builtin.package:
     name: "kubectl"


### PR DESCRIPTION
This commit fixes the name of the correct
docker.socket name instead of podman.socket.