### PR TITLE
ci: remove pagination when publishing in Galaxy

### DIFF
--- a/ci/release.sh
+++ b/ci/release.sh
@@ -46,7 +46,7 @@ fi
 namespace=kubeinit
 name=kubeinit
 
-all_published_versions=$(curl https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/$namespace/$name/versions/?format=json | jq -r '.data' | jq -c '.[].version')
+all_published_versions=$(curl -s "https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/$namespace/$name/versions/?format=json&limit=1000&offset=0" | jq -r '.data' | jq -c '.[].version')
 current_galaxy_version=$(cat kubeinit/galaxy.yml | shyaml get-value version)
 current_galaxy_namespace=$(cat kubeinit/galaxy.yml | shyaml get-value namespace)
 current_galaxy_name=$(cat kubeinit/galaxy.yml | shyaml get-value name)


### PR DESCRIPTION
This commit removes the pagination when getting
the published collection versions.